### PR TITLE
Speed up GeoJSON export

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,13 +17,14 @@ object Dependencies {
     val postgresql        = "9.1-901-1.jdbc4"
     val quasiQuotes       = "2.0.0"
     val rojomaJson        = "3.2.2"
+    val rojomaJsonGrisu   = "1.0.0"
     val rojomaSimpleArm   = "1.2.0"
     val rojomaSimpleArmV2 = "2.1.0"
     val scalaj            = "0.3.15"
     val socrataHttp       = "3.3.0"
     val soqlBrita         = "1.3.0"
     val soqlReference     = "0.5.1"
-    val thirdPartyUtils   = "3.0.0"
+    val thirdPartyUtils   = "3.1.1"
     val typesafeConfig    = "1.0.2"
 
     // Test
@@ -64,7 +65,7 @@ object Dependencies {
 
   val quasiQuotes              = "org.scalamacros" %% "quasiquotes"                 % versions.quasiQuotes
 
-  val rojomaJson               = "com.rojoma"      %% "rojoma-json-v3"              % versions.rojomaJson
+  val rojomaJson               = "com.rojoma"      %% "rojoma-json-v3-grisu"        % versions.rojomaJsonGrisu
 
   val rojomaSimpleArm          = "com.rojoma"      %% "simple-arm"                  % versions.rojomaSimpleArm
   val rojomaSimpleArmV2        = "com.rojoma"      %% "simple-arm-v2"               % versions.rojomaSimpleArmV2

--- a/soda-fountain-external/src/test/scala/com/socrata/soda/external/SodaFountainClientTest.scala
+++ b/soda-fountain-external/src/test/scala/com/socrata/soda/external/SodaFountainClientTest.scala
@@ -158,7 +158,7 @@ class SodaFountainClientTest extends FunSuite with Matchers with BeforeAndAfterA
 
     val result = sodaFountain.query("foo")
     result.getClass should be (classOf[Failed])
-    result.asInstanceOf[Failed].exception.getClass should be (classOf[ConnectFailed])
+    result.asInstanceOf[Failed].exception.getClass should be (MyCustomNoServersException.getClass)
 
     // Restart the mock server so the rest of the tests run normally
     mockServer.start()

--- a/soda-fountain-lib/src/test/scala/com/socrata/soda/server/resources/SuggestTest.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/soda/server/resources/SuggestTest.scala
@@ -332,6 +332,7 @@ class SuggestTest extends SpandexTestSuite with Matchers with MockFactory with T
     response.getStatus should be(HttpStatus.SC_NOT_FOUND)
   }
 
+  // Needs VPN to be on to pass on localhost, apparently
   test("spandex connect timeout") {
     setSpandexResponse(url = "/", body = "connect timeout", syntheticDelayMs = 10000)
     failAfter(2 seconds) {


### PR DESCRIPTION
- using the Grisu Double toString serializer
- using optimizations in third-party-utils GeoJSON encoder

GeoJSON export should be roughly an order of magnitude faster.