### PR TITLE
Krah/spandex error message

### DIFF
--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/SodaUtils.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/SodaUtils.scala
@@ -1,17 +1,18 @@
 package com.socrata.soda.server
 
+import java.nio.charset.{Charset, StandardCharsets}
+import javax.servlet.http.HttpServletRequest
+
 import com.rojoma.json.v3.codec._
 import com.rojoma.json.v3.io.CompactJsonWriter
 import com.socrata.http.server.HttpResponse
 import com.socrata.http.server.implicits._
 import com.socrata.http.server.responses._
 import com.socrata.http.server.util._
-import com.socrata.http.server.util.RequestId.{RequestId, ReqIdHeader}
+import com.socrata.http.server.util.RequestId.{ReqIdHeader, RequestId}
 import com.socrata.soda.server.errors.{InternalException, SodaError}
 import com.socrata.soda.server.id.{AbstractId, ResourceName}
 import com.socrata.soql.environment.AbstractName
-import java.nio.charset.{StandardCharsets, Charset}
-import javax.servlet.http.HttpServletRequest
 
 object SodaUtils {
   val errorLog = org.slf4j.LoggerFactory.getLogger("com.socrata.soda.server.Error")
@@ -21,7 +22,7 @@ object SodaUtils {
 
   val ResourceHeader = "X-Socrata-Resource"
 
-  def JsonContent[T : JsonEncode : JsonDecode](thing: T, charset: Charset): HttpResponse = {
+  def JsonContent[T: JsonEncode : JsonDecode](thing: T, charset: Charset): HttpResponse = {
     val j = JsonEncode[T].encode(thing)
     Write(jsonContentTypeBase + "; charset=" + charset.name) { out =>
       val jw = new CompactJsonWriter(out)
@@ -31,7 +32,7 @@ object SodaUtils {
   }
 
   @deprecated(message = "Need to negotiate a charset", since = "forever")
-  def JsonContent[T : JsonEncode : JsonDecode](thing: T): HttpResponse =
+  def JsonContent[T: JsonEncode : JsonDecode](thing: T): HttpResponse =
     JsonContent(thing, StandardCharsets.UTF_8)
 
   def errorResponse(req: HttpServletRequest, error: SodaError, logTags: LogTag*): HttpResponse = {
@@ -53,9 +54,10 @@ object SodaUtils {
           "data" -> JObject(error.sanitizedData)
         ))
         Json(content)
-      } else
-      // when passing unit, must pass using (()) as compiler will not infer () you meaning to pass Unit.
-        Function.const(())_
+      } else {
+        // when passing unit, must pass using (()) as compiler will not infer () you meaning to pass Unit.
+        Function.const(()) _
+      }
 
     header ~> potentialContent
   }
@@ -63,7 +65,7 @@ object SodaUtils {
   def internalError(request: HttpServletRequest, th: Throwable, logTags: LogTag*): HttpResponse = {
     val tag = java.util.UUID.randomUUID.toString
     errorLog.error("Internal exception: " + tag, th)
-    errorResponse(request, InternalException(th, tag), logTags:_*)
+    errorResponse(request, InternalException(th, tag), logTags: _*)
   }
 
   /**
@@ -81,7 +83,7 @@ class LogTag(s: String) {
 
 object LogTag {
   import scala.language.implicitConversions
-  implicit def s2tag(s: String) = new LogTag(s)
-  implicit def n2tag(n: AbstractName[_]) = new LogTag(n.name)
-  implicit def id2tag(i: AbstractId) = new LogTag(i.underlying)
+  implicit def s2tag(s: String): LogTag = new LogTag(s)
+  implicit def n2tag(n: AbstractName[_]): LogTag = new LogTag(n.name)
+  implicit def id2tag(i: AbstractId): LogTag = new LogTag(i.underlying)
 }

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/errors/SodaError.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/errors/SodaError.scala
@@ -1,11 +1,12 @@
 package com.socrata.soda.server.errors
 
+import javax.servlet.http.HttpServletResponse
+
 import com.rojoma.json.v3.ast.{JObject, JValue}
 import com.rojoma.json.v3.util.AutomaticJsonCodecBuilder
 import com.socrata.http.server.util.EntityTag
-import javax.servlet.http.HttpServletResponse
-import scala.{collection => sc}
 
+import scala.{collection => sc}
 
 abstract class SodaError(val httpResponseCode: Int, val errorCode: String, val data: Map[String, JValue]) {
   def this(httpResponseCode: Int, errorCode: String, data: (String, JValue)*) =
@@ -15,16 +16,18 @@ abstract class SodaError(val httpResponseCode: Int, val errorCode: String, val d
     })
 
   def this(errorCode: String, data: (String, JValue)*) =
-    this(HttpServletResponse.SC_BAD_REQUEST, errorCode, data : _*)
+    this(HttpServletResponse.SC_BAD_REQUEST, errorCode, data: _*)
 
   def etags: Seq[EntityTag] = Nil
+
   def vary: Option[String] = None
 
   // Some responses, such as NotModified, cannot have content according to HTTP 1.1
   def hasContent: Boolean = true
+
   def humanReadableMessage: String = SodaError.translate(errorCode, data)
 
-  def sanitizedData: Map[String, JValue] = data -  "stackTrace" - "errorClass"
+  def sanitizedData: Map[String, JValue] = data - "stackTrace" - "errorClass"
 }
 
 object SodaError {

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/errors/error.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/errors/error.scala
@@ -1,13 +1,14 @@
 package com.socrata.soda.server.errors
 
+import javax.activation.MimeType
 import javax.servlet.http.HttpServletResponse._
+
 import com.rojoma.json.v3.ast._
 import com.rojoma.json.v3.codec._
-import javax.activation.MimeType
-import com.socrata.soql.environment.{ColumnName, TypeName}
 import com.socrata.http.server.util.EntityTag
-import com.socrata.soda.server.id.{RollupName, ResourceName, RowSpecifier}
+import com.socrata.soda.server.id.{ResourceName, RollupName, RowSpecifier}
 import com.socrata.soda.server.wiremodels.ComputationStrategyType
+import com.socrata.soql.environment.{ColumnName, TypeName}
 
 case class ResourceNotModified(override val etags: Seq[EntityTag], override val vary: Option[String], override val hasContent: Boolean = false)
   extends SodaError(SC_NOT_MODIFIED, "not-modified")
@@ -26,10 +27,19 @@ case class InternalError(tag: String)
 
 case class InternalException(th: Throwable, tag: String)
   extends SodaError(SC_INTERNAL_SERVER_ERROR, "internal-error",
-    "tag" -> JString(tag),
-    "errorMessage" -> JString(th.getMessage),
+    "tag"          -> JString(tag),
+    "errorMessage" -> JString(Option(th.getMessage).getOrElse("")),
     "errorClass"   -> JString(th.getClass.getCanonicalName),
-    "stackTrace"   -> JArray(th.getStackTrace.map(x => JString(x.toString))))
+    "stackTrace"   -> JArray(th.getStackTrace.map(x => JString(x.toString)))
+  )
+
+case class HttpClientException(th: Throwable, msg: String, tag: String)
+  extends SodaError(SC_INTERNAL_SERVER_ERROR, "http-client-exception",
+    "tag"          -> JString(tag),
+    "errorMessage" -> JString(msg),
+    "errorClass"   -> JString(th.getClass.getCanonicalName),
+    "stackTrace"   -> JArray(th.getStackTrace.map(x => JString(x.toString)))
+  )
 
 case class HttpMethodNotAllowed(method: String, allowed: TraversableOnce[String])
   extends SodaError(SC_METHOD_NOT_ALLOWED, "method-not-allowed",

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/Suggest.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/Suggest.scala
@@ -9,10 +9,12 @@ import com.socrata.http.client.exceptions.{ConnectFailed, ConnectTimeout, Conten
 import com.socrata.http.server._
 import com.socrata.http.server.implicits._
 import com.socrata.http.server.responses._
+import com.socrata.soda.server.SodaUtils.errorResponse
 import com.socrata.soda.server.config.SuggestConfig
 import com.socrata.soda.server.copy.{Published, Stage}
 import com.socrata.soda.server.highlevel.{ColumnDAO, DatasetDAO}
 import com.socrata.soda.server.id.ResourceName
+import com.socrata.soda.server.{errors => SodaError}
 import com.socrata.soql.environment.ColumnName
 import com.socrata.thirdparty.metrics.Metrics
 
@@ -54,35 +56,24 @@ case class Suggest(datasetDao: DatasetDAO, columnDao: ColumnDAO,
     }
   }
 
-  case class SuggestError(error: Throwable) {
-    def json: JValue = {
-      JObject(Map(
-        "source"       -> JString("soda-fountain"),
-        "entity"       -> JString("Suggest"),
-        "errorMessage" -> JString(error.toString)
-      ))
-    }
-  }
-
   // f(dataset name, copy num or lifecycle stage, column name, text) => spandex uri to get
-  def go(req: HttpRequest, resp: HttpServletResponse,
+  def suggest(req: HttpRequest, resp: HttpServletResponse,
          resourceName: ResourceName, columnName: ColumnName, text: String,
          f: (String, Stage, String, String) => URI): Unit = {
+    def err(e: Throwable, msg: String): HttpResponse = {
+      errorResponse(com.socrata.soda.server.toServletHttpRequest(req), SodaError.HttpClientException(e, msg, "Suggest"))
+    }
     internalContext(resourceName, columnName) match {
       case None => NotFound(resp)
       case Some((ds: String, stage: Stage, col: String)) =>
-        val (code: Int, body: JValue) = try {
-          getSpandexResponse(f(ds, stage, col, text), req.queryParameters)
+        try {
+          val (code: Int, body: JValue) = getSpandexResponse(f(ds, stage, col, text), req.queryParameters)
+          (Status(code) ~> Json(body))(resp)
         } catch {
-          case rt: ReceiveTimeout => log.warn(s"Spandex receive timeout $rt")
-            (HttpServletResponse.SC_INTERNAL_SERVER_ERROR, SuggestError(rt).json)
-          case ct: ConnectTimeout => log.warn(s"Spandex connect timeout $ct")
-            (HttpServletResponse.SC_INTERNAL_SERVER_ERROR, SuggestError(ct).json)
-          case cf: ConnectFailed => log.warn(s"Spandex connect failed $cf")
-            (HttpServletResponse.SC_INTERNAL_SERVER_ERROR, SuggestError(cf).json)
+          case rt: ReceiveTimeout => err(rt, "Spandex receive timeout")(resp)
+          case ct: ConnectTimeout => err(ct, "Spandex connect timeout")(resp)
+          case cf: ConnectFailed => err(cf, "Spandex connect failed")(resp)
         }
-
-        (Status(code) ~> Json(body))(resp)
     }
   }
 
@@ -120,7 +111,7 @@ case class Suggest(datasetDao: DatasetDAO, columnDao: ColumnDAO,
   case class sampleService(resourceName: ResourceName, columnName: ColumnName) extends SodaResource {
     override def get = { req => resp =>
       sampleTimer.time {
-        go(req, resp, resourceName, columnName, "", (dataset, stage, column, _) =>
+        suggest(req, resp, resourceName, columnName, "", (dataset, stage, column, _) =>
           new URI(s"http://$spandexAddress/suggest/$dataset/$stage/$column"))
       }
     }
@@ -129,7 +120,7 @@ case class Suggest(datasetDao: DatasetDAO, columnDao: ColumnDAO,
   case class service(resourceName: ResourceName, columnName: ColumnName, text: String) extends SodaResource {
     override def get = { req => resp =>
       suggestTimer.time {
-        go(req, resp, resourceName, columnName, text, (dataset, stage, column, text) => {
+        suggest(req, resp, resourceName, columnName, text, (dataset, stage, column, text) => {
           // protect param 'text' from arbitrary url insertion
           val encText = java.net.URLEncoder.encode(text, "utf-8")
           new URI(s"http://$spandexAddress/suggest/$dataset/$stage/$column/$encText")

--- a/soda-fountain-lib/src/test/scala/com/socrata/soda/server/resources/SuggestTest.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/soda/server/resources/SuggestTest.scala
@@ -352,14 +352,13 @@ class SuggestTest extends SpandexTestSuite with Matchers with MockFactory with T
     servReq.expects('getQueryString)()
     val augReq = new AugmentedHttpServletRequest(servReq)
     val httpReq = mock[HttpRequest]
-    httpReq.expects('servletRequest)().returning(augReq)
+    httpReq.expects('servletRequest)().anyNumberOfTimes.returning(augReq)
 
     val response = new MockHttpServletResponse()
     suggest.service(resourceName, columnName, suggestText).get(httpReq)(response)
     response.getContentType should include("application/json")
     response.getStatus should be(HttpStatus.SC_INTERNAL_SERVER_ERROR)
-    response.getContentAsString should include("Suggest")
-    response.getContentAsString should include("com.socrata.http.client.exceptions.ConnectFailed")
+    response.getContentAsString should include("Spandex connect failed")
   }
   test("spandex connect timeout - send error message in response") {
     val d = mock[DatasetDAO]
@@ -385,14 +384,13 @@ class SuggestTest extends SpandexTestSuite with Matchers with MockFactory with T
     servReq.expects('getQueryString)()
     val augReq = new AugmentedHttpServletRequest(servReq)
     val httpReq = mock[HttpRequest]
-    httpReq.expects('servletRequest)().returning(augReq)
+    httpReq.expects('servletRequest)().anyNumberOfTimes.returning(augReq)
 
     val response = new MockHttpServletResponse()
     suggest.service(resourceName, columnName, suggestText).get(httpReq)(response)
     response.getContentType should include("application/json")
     response.getStatus should be(HttpStatus.SC_INTERNAL_SERVER_ERROR)
-    response.getContentAsString should include("Suggest")
-    response.getContentAsString should include("com.socrata.http.client.exceptions.ConnectTimeout")
+    response.getContentAsString should include("Spandex connect timeout")
   }
   test("spandex receive timeout - send error message in response") {
     val d = mock[DatasetDAO]
@@ -410,13 +408,12 @@ class SuggestTest extends SpandexTestSuite with Matchers with MockFactory with T
     servReq.expects('getQueryString)()
     val augReq = new AugmentedHttpServletRequest(servReq)
     val httpReq = mock[HttpRequest]
-    httpReq.expects('servletRequest)().returning(augReq)
+    httpReq.expects('servletRequest)().anyNumberOfTimes.returning(augReq)
 
     val response = new MockHttpServletResponse()
     suggest.service(resourceName, columnName, suggestText).get(httpReq)(response)
     response.getContentType should include("application/json")
     response.getStatus should be(HttpStatus.SC_INTERNAL_SERVER_ERROR)
-    response.getContentAsString should include("Suggest")
-    response.getContentAsString should include("com.socrata.http.client.exceptions.ReceiveTimeout")
+    response.getContentAsString should include("Spandex receive timeout")
   }
 }


### PR DESCRIPTION
I thought maybe we should give a better error message than "null" when soda-fountain couldn't get a spandex response for some reasons.