### PR TITLE
Run metasoda migrations when the container starts.

### DIFF
--- a/docker/ship.d/run
+++ b/docker/ship.d/run
@@ -3,7 +3,7 @@ set -ev
 
 /bin/env_parse ${SERVER_CONFIG}.j2
 
-exec su socrata -c '/usr/bin/java \
+su socrata -c '/usr/bin/java \
     -Dconfig.file=${SERVER_CONFIG} \
     -cp $SERVER_ARTIFACT \
     com.socrata.soda.server.MigrateSchema migrate'

--- a/docker/ship.d/run
+++ b/docker/ship.d/run
@@ -4,6 +4,11 @@ set -ev
 /bin/env_parse ${SERVER_CONFIG}.j2
 
 exec su socrata -c '/usr/bin/java \
+    -Dconfig.file=${SERVER_CONFIG} \
+    -cp $SERVER_ARTIFACT \
+    com.socrata.soda.server.MigrateSchema migrate'
+
+exec su socrata -c '/usr/bin/java \
     -Xmx${JAVA_XMX} \
     -Xms${JAVA_XMX} \
     -Dconfig.file=${SERVER_CONFIG} \


### PR DESCRIPTION
Most of our migrations are ideally run _before_ a new version of a service is running. In some cases, not running the migrations beforehand can lead to outages. 

It's not uncommon that we forget to run migrations at the appropriate time to each environment; this change makes sure that never happens. 

The upshot of this is that if we have a migration that needs to be run *after* changes to the service, we'd need to deploy the service code change and the migration in 2 separate steps.