### PR TITLE
Disallow source columns from being deleted without removing the dependency first

### DIFF
--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/errors/error.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/errors/error.scala
@@ -143,6 +143,12 @@ case class RowNotFound(value: RowSpecifier)
   extends SodaError(SC_NOT_FOUND, "soda.row.not-found",
      "value" -> JString(value.underlying))
 
+case class ColumnHasDependencies(columnName: ColumnName,
+                                 deps: Seq[ColumnName])
+  extends SodaError(SC_BAD_REQUEST, "soda.column-with-dependencies-not-deleteable",
+     "column"       -> JString(columnName.name),
+     "dependencies" -> JArray(deps.map { d => JString(d.name) }))
+
 /**
  * Column not found in a row operation
  */

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/ColumnDAO.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/ColumnDAO.scala
@@ -38,6 +38,7 @@ object ColumnDAO {
   case class ColumnNotFound(column: ColumnName) extends Result
   case class Deleted(rec: ColumnRecord, etag: Option[EntityTag]) extends Result
   case class InvalidColumnName(name: ColumnName) extends Result
+  case class ColumnHasDependencies(rec: ColumnName) extends Result
   case class InvalidRowIdOperation(columnRec: ColumnRecord, method: String) extends Result
   case class NonUniqueRowId(rec: ColumnRecord) extends Result
   case class InvalidDatasetState(data: Map[String, JValue]) extends Result

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/ColumnDAO.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/ColumnDAO.scala
@@ -37,8 +37,8 @@ object ColumnDAO {
   case class DatasetNotFound(dataset: ResourceName) extends Result
   case class ColumnNotFound(column: ColumnName) extends Result
   case class Deleted(rec: ColumnRecord, etag: Option[EntityTag]) extends Result
-  case class InvalidColumnName(name: ColumnName) extends Result
-  case class ColumnHasDependencies(rec: ColumnName, deps: Seq[ColumnName]) extends Result
+  case class InvalidColumnName(col: ColumnName) extends Result
+  case class ColumnHasDependencies(col: ColumnName, deps: Seq[ColumnName]) extends Result
   case class InvalidRowIdOperation(columnRec: ColumnRecord, method: String) extends Result
   case class NonUniqueRowId(rec: ColumnRecord) extends Result
   case class InvalidDatasetState(data: Map[String, JValue]) extends Result

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/ColumnDAO.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/ColumnDAO.scala
@@ -38,7 +38,7 @@ object ColumnDAO {
   case class ColumnNotFound(column: ColumnName) extends Result
   case class Deleted(rec: ColumnRecord, etag: Option[EntityTag]) extends Result
   case class InvalidColumnName(name: ColumnName) extends Result
-  case class ColumnHasDependencies(rec: ColumnName) extends Result
+  case class ColumnHasDependencies(rec: ColumnName, deps: Seq[ColumnName]) extends Result
   case class InvalidRowIdOperation(columnRec: ColumnRecord, method: String) extends Result
   case class NonUniqueRowId(rec: ColumnRecord) extends Result
   case class InvalidDatasetState(data: Map[String, JValue]) extends Result

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/DatasetColumn.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/DatasetColumn.scala
@@ -7,7 +7,7 @@ import com.socrata.http.server.responses._
 import com.socrata.http.server.util.{EntityTag, Precondition, RequestId}
 import com.socrata.soda.server._
 import com.socrata.soda.server.computation.ComputedColumnsLike
-import com.socrata.soda.server.errors.{EtagPreconditionFailed, HttpMethodNotAllowed, NonUniqueRowId, ResourceNotModified}
+import com.socrata.soda.server.errors._
 import com.socrata.soda.server.highlevel._
 import com.socrata.soda.server.id.ResourceName
 import com.socrata.soda.server.util.ETagObfuscator
@@ -43,6 +43,8 @@ case class DatasetColumn(columnDAO: ColumnDAO, exportDAO: ExportDAO, rowDAO: Row
       case ColumnDAO.ColumnNotFound(column) => NotFound /* TODO: content */
       case ColumnDAO.DatasetNotFound(dataset) => NotFound /* TODO: content */
       case ColumnDAO.InvalidColumnName(column) => BadRequest /* TODO: content */
+      case ColumnDAO.ColumnHasDependencies(col, deps) =>
+        SodaUtils.errorResponse(req, ColumnHasDependencies(col, deps))
       case ColumnDAO.InvalidRowIdOperation(column, method) =>
         SodaUtils.errorResponse(req, HttpMethodNotAllowed(method, Seq("GET", "PATCH")))
       case ColumnDAO.NonUniqueRowId(column) =>

--- a/soda-fountain-lib/src/test/scala/com/socrata/soda/server/highlevel/ColumnDAOSpec.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/soda/server/highlevel/ColumnDAOSpec.scala
@@ -34,6 +34,7 @@ class ColumnDAOSpec extends FunSuiteLike
   test("Delete column with dependency") {
     val dataset = TestDatasetWithComputedColumn.dataset
     val toDelete = dataset.col("source")
+    val dependency = dataset.col(":computed")
     val requestId = "1234"
 
     val dc = mock[DataCoordinatorClient]
@@ -46,7 +47,7 @@ class ColumnDAOSpec extends FunSuiteLike
 
     val result = dao.deleteColumn("user", dataset.resourceName, toDelete.fieldName, requestId)
 
-    result should be(ColumnHasDependencies(toDelete.fieldName))
+    result should be(ColumnHasDependencies(toDelete.fieldName, Seq(dependency.fieldName)))
   }
 
   test("Delete column") {

--- a/soda-fountain-lib/src/test/scala/com/socrata/soda/server/highlevel/ColumnDAOSpec.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/soda/server/highlevel/ColumnDAOSpec.scala
@@ -1,0 +1,70 @@
+package com.socrata.soda.server.highlevel
+
+import com.socrata.soda.clients.datacoordinator.DataCoordinatorClient
+import com.socrata.soda.server.DatasetsForTesting
+import com.socrata.soda.server.copy.Latest
+import com.socrata.soda.server.highlevel.ColumnDAO._
+import com.socrata.soda.server.persistence.NameAndSchemaStore
+import com.socrata.soql.environment.ColumnName
+import org.scalamock.proxy.ProxyMockFactory
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.{Matchers, FunSuiteLike}
+import scala.util.Random
+
+class ColumnDAOSpec extends FunSuiteLike
+  with Matchers with MockFactory with ProxyMockFactory with DatasetsForTesting {
+
+  test("Delete nonexistent column") {
+    val dataset = TestDatasetWithComputedColumn.dataset
+    val toDelete = ColumnName("blah")
+
+    val dc = mock[DataCoordinatorClient]
+    val ns = mock[NameAndSchemaStore]
+    ns.expects('lookupDataset)(dataset.resourceName, Some(Latest))
+      .returning(Some(dataset)).anyNumberOfTimes()
+    val col = new ColumnSpecUtils(Random)
+
+    val dao: ColumnDAO = new ColumnDAOImpl(dc, ns, col)
+
+    val result = dao.deleteColumn("user", dataset.resourceName, toDelete, "1234")
+
+    result should be(ColumnNotFound(toDelete))
+  }
+
+  test("Delete column with dependency") {
+    val dataset = TestDatasetWithComputedColumn.dataset
+    val toDelete = dataset.col("source")
+    val requestId = "1234"
+
+    val dc = mock[DataCoordinatorClient]
+    val ns = mock[NameAndSchemaStore]
+    ns.expects('lookupDataset)(dataset.resourceName, Some(Latest))
+      .returning(Some(dataset)).anyNumberOfTimes()
+    val col = new ColumnSpecUtils(Random)
+
+    val dao: ColumnDAO = new ColumnDAOImpl(dc, ns, col)
+
+    val result = dao.deleteColumn("user", dataset.resourceName, toDelete.fieldName, requestId)
+
+    result should be(ColumnHasDependencies(toDelete.fieldName))
+  }
+
+  test("Delete column") {
+    val dataset = TestDatasetWithComputedColumn.dataset
+    val toDelete = dataset.col(":computed")
+    val requestId = "1234"
+
+    val dc = mock[DataCoordinatorClient]
+    val ns = mock[NameAndSchemaStore]
+    ns.expects('lookupDataset)(dataset.resourceName, Some(Latest))
+      .returning(Some(dataset)).anyNumberOfTimes()
+    dc.expects('update)(*, *, *, *, *, *)
+    val col = new ColumnSpecUtils(Random)
+
+    val dao: ColumnDAO = new ColumnDAOImpl(dc, ns, col)
+
+    dao.deleteColumn("user", dataset.resourceName, toDelete.fieldName, requestId)
+
+    // TODO : How can we pass in/validate the handler function passed to dc.update?
+  }
+}


### PR DESCRIPTION
The lack of validation for this scenario has resulted in some hairy situations in production - let's just prevent it from happening in the first place.