### PR TITLE
Refs CORE-5975

### DIFF
--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/export/CJsonExporter.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/export/CJsonExporter.scala
@@ -19,7 +19,13 @@ object CJsonExporter extends Exporter {
   val mimeType = new MimeType(mimeTypeBase)
   val extension = Some("cjson")
 
-  def export(resp: HttpServletResponse, charset: AliasedCharset, schema: ExportDAO.CSchema, rows: Iterator[Array[SoQLValue]], singleRow: Boolean = false) {
+  def export(resp: HttpServletResponse,
+    charset: AliasedCharset,
+    schema: ExportDAO.CSchema,
+    rows: Iterator[Array[SoQLValue]],
+    singleRow: Boolean = false,
+    options: Map[String, String] = Map()
+  ) {
     val mt = new MimeType(mimeTypeBase)
     mt.setParameter("charset", charset.alias)
     resp.setContentType(mt.toString)

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/export/CsvExporter.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/export/CsvExporter.scala
@@ -14,7 +14,13 @@ object CsvExporter extends Exporter {
   val mimeType = new MimeType(mimeTypeBase)
   val extension = Some("csv")
 
-  def export(resp: HttpServletResponse, charset: AliasedCharset, schema: ExportDAO.CSchema, rows: Iterator[Array[SoQLValue]], singleRow: Boolean = false) {
+  def export(resp: HttpServletResponse,
+    charset: AliasedCharset,
+    schema: ExportDAO.CSchema,
+    rows: Iterator[Array[SoQLValue]],
+    singleRow: Boolean = false,
+    options: Map[String, String] = Map()
+  ) {
     val mt = new MimeType(mimeTypeBase)
     mt.setParameter("charset", charset.alias)
     resp.setContentType(mt.toString)

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/export/Exporter.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/export/Exporter.scala
@@ -7,12 +7,20 @@ import com.socrata.soql.types.SoQLValue
 import java.util.Locale
 import javax.activation.MimeType
 import javax.servlet.http.HttpServletResponse
+import com.socrata.http.server.HttpRequest
 
 trait Exporter {
   val mimeType: MimeType
   val extension: Option[String]
-  def export(resp: HttpServletResponse, charset: AliasedCharset, schema: ExportDAO.CSchema, rows: Iterator[Array[SoQLValue]], singleRow: Boolean = false)
+  def export(resp: HttpServletResponse,
+    charset: AliasedCharset,
+    schema: ExportDAO.CSchema,
+    rows: Iterator[Array[SoQLValue]],
+    singleRow: Boolean = false,
+    options: Map[String, String] = Map()
+  )
   def validForSchema(schema: Seq[ColumnRecordLike]): Boolean = true
+  def pluckOptions(req: HttpRequest): Map[String, String] = Map()
 }
 
 object Exporter {

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/export/JsonExporter.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/export/JsonExporter.scala
@@ -22,7 +22,13 @@ object JsonExporter extends Exporter {
   val xhDeprecation = "X-SODA2-Warning"
   val xhLimit = 5000 // We have a 6k header size limit
 
-  def export(resp: HttpServletResponse, charset: AliasedCharset, schema: ExportDAO.CSchema, rows: Iterator[Array[SoQLValue]], singleRow: Boolean = false) {
+  def export(resp: HttpServletResponse,
+    charset: AliasedCharset,
+    schema: ExportDAO.CSchema,
+    rows: Iterator[Array[SoQLValue]],
+    singleRow: Boolean = false,
+    options: Map[String, String] = Map()
+  ) {
     val mt = new MimeType(mimeTypeBase)
     mt.setParameter("charset", charset.alias)
     resp.setContentType(mt.toString)

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/export/SoQLPackExporter.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/export/SoQLPackExporter.scala
@@ -30,7 +30,8 @@ object SoQLPackExporter extends Exporter {
              charset: AliasedCharset,
              schema: ExportDAO.CSchema,
              rows: Iterator[Array[SoQLValue]],
-             singleRow: Boolean = false) {
+             singleRow: Boolean = false,
+             options: Map[String, String] = Map()) {
     val mt = new MimeType(mimeTypeBase)
     resp.setContentType(mt.toString)
     for {

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/Export.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/Export.scala
@@ -111,7 +111,8 @@ case class Export(exportDAO: ExportDAO, etagObfuscator: ETagObfuscator) {
                 newTag.foreach { tag =>
                   ETag(prepareTag(tag))(resp)
                 }
-                exporter.export(resp, charset, schema, rows)
+                log.info(s"Exporting with options ${exporter.pluckOptions(req)}")
+                exporter.export(resp, charset, schema, rows, options = exporter.pluckOptions(req))
               case ExportDAO.PreconditionFailed =>
                 SodaUtils.errorResponse(req, EtagPreconditionFailed)(resp)
               case ExportDAO.NotModified(etags) =>


### PR DESCRIPTION
Add a GET request query parameter to the /export endpoint
which will explicitly specify the CRS of the export.
Not going to name names, but this is needed
for certain libraries that crash when you parse geoJSON
which follows the spec correctly and includes the CRS.
Currently only crs84 is supported, and that is all that
will be supported because anything else will break the
geoJSON spec.