### PR TITLE
Remove unnecessarily noisy table dropper log messages

### DIFF
--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/SodaFountain.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/SodaFountain.scala
@@ -201,7 +201,6 @@ class SodaFountain(config: SodaFountainConfig) extends Closeable {
 
     override def run() {
       do {
-        log.info("Checking for datasets to drop...")
         try {
           val records = store.lookupDroppedDatasets(tableDropDelay)
           records.foreach { rec =>


### PR DESCRIPTION
This log message currently spams the soda fountain log every 30 seconds - removing it.