### PR TITLE
Fix dataset lookup bug

### DIFF
--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/persistence/pg/PostgresStoreImpl.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/persistence/pg/PostgresStoreImpl.scala
@@ -76,7 +76,7 @@ class PostgresStoreImpl(dataSource: DataSource) extends NameAndSchemaStore {
   //than duplicating the functions
   def translateResourceName(resourceName: ResourceName, stage: Option[Stage] = None, isDeleted: Boolean = false): Option[MinimalDatasetRecord] = {
     using(dataSource.getConnection()){ connection =>
-      val dcDeletedFilter = if (!isDeleted) " AND dc.deleted_at is null" else " AND dc.deleted_at is not null"
+      val dcDeletedFilter = if (!isDeleted) " AND deleted_at is null" else " AND deleted_at is not null"
       val dDeletedFilter = if (!isDeleted) " AND d.deleted_at is null" else " AND d.deleted_at is not null"
       using(connection.prepareStatement(
         s"""


### PR DESCRIPTION
Subtle bug in the dataset lookup SQL query that prevents the most recent dataset copies from being returned if there have been any discarded working copy on a dataset. This prevents any subsequent working copies from being created.