### PR TITLE
EN-158 Passes comp strategies onto datacoordinator

### DIFF
--- a/soda-fountain-lib/src/main/resources/com/socrata/soda/server/persistence/pg/20160216-drop-recompute-from-computation-strategies.xml
+++ b/soda-fountain-lib/src/main/resources/com/socrata/soda/server/persistence/pg/20160216-drop-recompute-from-computation-strategies.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <changeSet author="Alexa Rust" id="20160216-drop-recompute-from-computation-strategies">
+        <sqlFile path="com/socrata/soda/server/persistence/pg/sql/drop_recompute_from_computation_strategies.sql"/>
+    </changeSet>
+</databaseChangeLog>

--- a/soda-fountain-lib/src/main/resources/com/socrata/soda/server/persistence/pg/migrate.xml
+++ b/soda-fountain-lib/src/main/resources/com/socrata/soda/server/persistence/pg/migrate.xml
@@ -12,4 +12,5 @@
     <include file="com/socrata/soda/server/persistence/pg/20150501-add-missing-timezone.xml"/>
 
     <include file="com/socrata/soda/server/persistence/pg/21050724-add-deleted-at-column-multi-tables.xml"/>
+    <include file="com/socrata/soda/server/persistence/pg/20160216-drop-recompute-from-computation-strategies.xml"/>
 </databaseChangeLog>

--- a/soda-fountain-lib/src/main/resources/com/socrata/soda/server/persistence/pg/sql/drop_recompute_from_computation_strategies.sql
+++ b/soda-fountain-lib/src/main/resources/com/socrata/soda/server/persistence/pg/sql/drop_recompute_from_computation_strategies.sql
@@ -1,0 +1,2 @@
+ALTER TABLE computation_strategies
+DROP COLUMN recompute;

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/datacoordinator/ColumnMutation.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/datacoordinator/ColumnMutation.scala
@@ -1,20 +1,41 @@
 package com.socrata.soda.clients.datacoordinator
 
-import com.rojoma.json.v3.util.JsonUtil
+import com.rojoma.json.v3.codec.JsonEncode
+import com.rojoma.json.v3.util.{AutomaticJsonCodecBuilder, Strategy, JsonKeyStrategy, JsonUtil}
 import com.rojoma.json.v3.ast._
+import com.socrata.soda.server.wiremodels.{ComputationStrategySpec, ComputationStrategyType}
+import com.socrata.soql.environment.ColumnName
 import com.socrata.soql.types.SoQLType
 import com.socrata.soda.server.id.ColumnId
+
+@JsonKeyStrategy(Strategy.Underscore)
+case class ComputationStrategyInfo(strategyType: ComputationStrategyType.Value, sourceColumnIds: Seq[ColumnId], parameters: JObject)
+
+object ComputationStrategyInfo {
+
+  def apply(spec: ComputationStrategySpec): ComputationStrategyInfo = {
+    val ComputationStrategySpec(strategyType, sourceColumns, parameters) = spec
+    ComputationStrategyInfo(
+      strategyType,
+      sourceColumns.getOrElse(Seq()).map{ columnSpec => columnSpec.id },
+      parameters.getOrElse(JObject(Map()))
+    )
+  }
+
+  implicit val jsonCodec = AutomaticJsonCodecBuilder[ComputationStrategyInfo]
+}
 
 sealed abstract class ColumnMutation extends DataCoordinatorInstruction {
   override def toString = JsonUtil.renderJson(asJson)
 }
 
-case class AddColumnInstruction(dataType: SoQLType, hint: String, id: Option[ColumnId]) extends CM {
+case class AddColumnInstruction(dataType: SoQLType, fieldName: ColumnName, id: Option[ColumnId], computationStrategy: Option[ComputationStrategySpec]) extends CM {
   def asJson = JObject(Map(
     "c"     -> JString("add column"),
-    "hint"  -> JString(hint),
+    "field_name"  -> JString(fieldName.name),
     "type"  -> JString(dataType.name.name)) ++ id.map { cid =>
-    "id" -> JString(cid.underlying)
+    "id" -> JString(cid.underlying)} ++ computationStrategy.map { strategy =>
+    "computation_strategy" -> JsonEncode.toJValue[ComputationStrategyInfo](ComputationStrategyInfo(strategy))
   })
 }
 

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/computation/ComputedColumnsLike.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/computation/ComputedColumnsLike.scala
@@ -21,13 +21,14 @@ trait ComputedColumnsLike {
   val handlers: Map[ComputationStrategyType.Value, () => ComputationHandler]
 
   /**
-   * Finds the computed columns from the dataset schema.
+   * Finds the synchronously (in soda-fountain) computed columns from the dataset schema.
    *
    * @param datasetRecord containing the schema of the dataset
-   * @return a Seq[ColumnRecord] containing all the columns described in the dataset with a computationStrategy
+   * @return a Seq[ColumnRecord] containing all the columns described in the dataset with a synchronous computationStrategy
    */
   def findComputedColumns(datasetRecord: DatasetRecordLike): Seq[ColumnRecordLike] =
-    datasetRecord.columns.filter { col => col.computationStrategy.isDefined }
+    datasetRecord.columns.filter { col => col.computationStrategy.isDefined &&
+      ComputationStrategyType.computeSynchronously(col.computationStrategy.get.strategyType) }
 
   /**
    * Performs the (hopefully lazy) computation of all computed columns, producing a new iterator with

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/computation/ComputedColumnsLike.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/computation/ComputedColumnsLike.scala
@@ -21,14 +21,13 @@ trait ComputedColumnsLike {
   val handlers: Map[ComputationStrategyType.Value, () => ComputationHandler]
 
   /**
-   * Finds the synchronously (in soda-fountain) computed columns from the dataset schema.
+   * Finds the computed columns from the dataset schema.
    *
    * @param datasetRecord containing the schema of the dataset
    * @return a Seq[ColumnRecord] containing all the columns described in the dataset with a computationStrategy
    */
-  def findComputedColumns(datasetRecord: DatasetRecordLike): Seq[ColumnRecordLike] = {
+  def findComputedColumns(datasetRecord: DatasetRecordLike): Seq[ColumnRecordLike] =
     datasetRecord.columns.filter { col => col.computationStrategy.isDefined }
-  }
 
   /**
    * Performs the (hopefully lazy) computation of all computed columns, producing a new iterator with
@@ -40,21 +39,25 @@ trait ComputedColumnsLike {
    *                 For upserts, each row is a Map[String, SoQLValue], where the key is the
    *                 columnId and the value is a SoQLValue representation of source data.
    *                 Deletes contain only row PK and can be ignored.
-   * @param computedColumns the list of computed columns from [[findComputedColumns]]
+   * @param computedColumns the list of computed columns from [[findComputedColumns]] (not always true)
    */
   def addComputedColumns(requestId: RequestId,
                          sourceIt: Iterator[RowDataTranslator.Computable],
                          computedColumns: Seq[ColumnRecordLike]): ComputeResult = {
     var rowIterator = sourceIt
     for (computedColumn <- computedColumns) {
-      val tryGetHandler = handlers.get(computedColumn.computationStrategy.get.strategyType)
-      tryGetHandler match {
-        case Some(handlerCreator) =>
-          val handler = handlerCreator()
-          rowIterator = new ManagedIterator(handler.compute(
-            requestId, rowIterator, computedColumn), handler)
-        case None =>
-          return HandlerNotFound(computedColumn.computationStrategy.get.strategyType)
+      val strategyType = computedColumn.computationStrategy.get.strategyType
+      // only add computed columns that have synchronous computation strategies
+      if (ComputationStrategyType.computeSynchronously(strategyType)) {
+        val tryGetHandler = handlers.get(strategyType)
+        tryGetHandler match {
+          case Some(handlerCreator) =>
+            val handler = handlerCreator()
+            rowIterator = new ManagedIterator(handler.compute(
+              requestId, rowIterator, computedColumn), handler)
+          case None =>
+            return HandlerNotFound(strategyType)
+        }
       }
     }
     ComputeSuccess(rowIterator)

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/computation/ComputedColumnsLike.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/computation/ComputedColumnsLike.scala
@@ -24,11 +24,11 @@ trait ComputedColumnsLike {
    * Finds the synchronously (in soda-fountain) computed columns from the dataset schema.
    *
    * @param datasetRecord containing the schema of the dataset
-   * @return a Seq[ColumnRecord] containing all the columns described in the dataset with a synchronous computationStrategy
+   * @return a Seq[ColumnRecord] containing all the columns described in the dataset with a computationStrategy
    */
-  def findComputedColumns(datasetRecord: DatasetRecordLike): Seq[ColumnRecordLike] =
-    datasetRecord.columns.filter { col => col.computationStrategy.isDefined &&
-      ComputationStrategyType.computeSynchronously(col.computationStrategy.get.strategyType) }
+  def findComputedColumns(datasetRecord: DatasetRecordLike): Seq[ColumnRecordLike] = {
+    datasetRecord.columns.filter { col => col.computationStrategy.isDefined }
+  }
 
   /**
    * Performs the (hopefully lazy) computation of all computed columns, producing a new iterator with

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/computation/GeoregionMatchOnPointHandler.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/computation/GeoregionMatchOnPointHandler.scala
@@ -34,7 +34,7 @@ class GeoregionMatchOnPointHandler[T](config: Config, discovery: ServiceDiscover
   protected def genEndpoint(computedColumn: ColumnRecordLike): String = {
     require(computedColumn.computationStrategy.isDefined, "No computation strategy found")
     computedColumn.computationStrategy match {
-      case Some(ComputationStrategyRecord(_, _, _, Some(JObject(params)))) =>
+      case Some(ComputationStrategyRecord(_, _, Some(JObject(params)))) =>
         require(params.contains("region"), "parameters does not contain 'region'")
         val JString(region) = params("region")
         // Falling back to a default primary_key so we don't break things

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/computation/GeoregionMatchOnStringHandler.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/computation/GeoregionMatchOnStringHandler.scala
@@ -33,7 +33,7 @@ class GeoregionMatchOnStringHandler[T](config: Config, discovery: ServiceDiscove
   protected def genEndpoint(computedColumn: ColumnRecordLike): String = {
     require(computedColumn.computationStrategy.isDefined, "No computation strategy found")
     computedColumn.computationStrategy match {
-      case Some(ComputationStrategyRecord(_, _, _, Some(JObject(params)))) =>
+      case Some(ComputationStrategyRecord(_, _, Some(JObject(params)))) =>
         require(params.contains("region"), "parameters does not contain 'region'")
         require(params.contains("column"), "parameters does not contain 'column'")
         val JString(region) = params("region")

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/computation/TestComputationHandler.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/computation/TestComputationHandler.scala
@@ -33,7 +33,7 @@ class TestComputationHandler extends ComputationHandler {
 
   def parseStrategy(computationStrategy: ComputationStrategyRecord): (String, String) = {
     computationStrategy match {
-      case ComputationStrategyRecord(_, _, Some(Seq(sourceCol)), Some(JObject(map))) =>
+      case ComputationStrategyRecord(_, Some(Seq(sourceCol)), Some(JObject(map))) =>
         require(map.contains("concat_text"), "parameters does not contain 'concat_text'")
         val JString(concatText) = map("concat_text")
         (sourceCol.id.underlying, concatText)

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/ColumnDAOImpl.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/ColumnDAOImpl.scala
@@ -56,7 +56,7 @@ class ColumnDAOImpl(dc: DataCoordinatorClient, store: NameAndSchemaStore, column
           case Precondition.Passed =>
             val extraHeaders = Map(ReqIdHeader -> requestId,
                                    SodaUtils.ResourceHeader -> datasetRecord.resourceName.name)
-            val addColumn = AddColumnInstruction(spec.datatype, spec.fieldName.name, Some(spec.id))
+            val addColumn = AddColumnInstruction(spec.datatype, spec.fieldName, Some(spec.id), spec.computationStrategy)
             dc.update(datasetRecord.systemId, datasetRecord.schemaHash, user,
                       Iterator.single(addColumn), extraHeaders) {
               case DataCoordinatorClient.NonCreateScriptResult(report, etag, copyNumber, newVersion, lastModified) =>

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/DatasetDAOImpl.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/DatasetDAOImpl.scala
@@ -85,7 +85,7 @@ class DatasetDAOImpl(dc: DataCoordinatorClient, store: NameAndSchemaStore, colum
             List(new SetRowIdColumnInstruction(spec.columns(ridFieldName).id))
           }
         // ok cool.  First send it upstream, then if that works stick it in the store.
-        val columnInstructions = spec.columns.values.map { c => new AddColumnInstruction(c.datatype, c.fieldName.name, Some(c.id)) }
+        val columnInstructions = spec.columns.values.map { c => new AddColumnInstruction(c.datatype, c.fieldName, Some(c.id), c.computationStrategy) }
 
         val instructions = columnInstructions ++ addRidInstruction
 

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/RowDAO.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/RowDAO.scala
@@ -91,7 +91,7 @@ object RowDAO {
   case object CannotDeletePrimaryKey extends UpsertFailResult
   case class InvalidRequest(client: String, status: Int, body: JValue) extends UpsertFailResult
   case class RowNotAnObject(value: JValue) extends UpsertFailResult
-  case class  InternalServerError(status: Int = 500, client: String = "QC", code: String, tag: String, data: String) extends UpsertFailResult
+  case class InternalServerError(status: Int = 500, client: String = "QC", code: String, tag: String, data: String) extends UpsertFailResult
 
   // UPSERT FAILURE: QueryCoordinator
   case class QCError(status: Int, error: QueryCoordinatorError) extends UpsertFailResult

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/RowDataTranslator.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/RowDataTranslator.scala
@@ -77,11 +77,7 @@ class RowDataTranslator(requestId: RequestId,
       UpsertAsSoQL(fieldMap.toMap)
     }
 
-    transformRowsForUpsert(
-      cc,
-      toCompute.filter(col => ComputationStrategyType.computeSynchronously(col.computationStrategy.get.strategyType)),
-      computableRows
-    )
+    transformRowsForUpsert(cc, toCompute,computableRows)
   }
 
   private def transformRowsForUpsert(cc: ComputedColumnsLike,

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/RowDataTranslator.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/RowDataTranslator.scala
@@ -77,7 +77,11 @@ class RowDataTranslator(requestId: RequestId,
       UpsertAsSoQL(fieldMap.toMap)
     }
 
-    transformRowsForUpsert(cc, toCompute, computableRows)
+    transformRowsForUpsert(
+      cc,
+      toCompute.filter(col => ComputationStrategyType.computeSynchronously(col.computationStrategy.get.strategyType)),
+      computableRows
+    )
   }
 
   private def transformRowsForUpsert(cc: ComputedColumnsLike,

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/package.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/package.scala
@@ -38,7 +38,7 @@ package object highlevel {
         // Value of last 3 params is never used
         MinimalColumnRecord(col.id, col.fieldName, SoQLNull, false, None)
       })
-      ComputationStrategyRecord(css.strategyType, css.recompute, sourceColumns, css.parameters)
+      ComputationStrategyRecord(css.strategyType, sourceColumns, css.parameters)
     }
   }
 
@@ -47,7 +47,7 @@ package object highlevel {
       val sourceColumns = csr.sourceColumns.map(_.map { col =>
         SourceColumnSpec(col.id, col.fieldName)
       })
-      ComputationStrategySpec(csr.strategyType, csr.recompute, sourceColumns, csr.parameters)
+      ComputationStrategySpec(csr.strategyType, sourceColumns, csr.parameters)
     }
   }
 

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/persistence/NameAndSchemaStore.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/persistence/NameAndSchemaStore.scala
@@ -74,7 +74,6 @@ trait ColumnRecordLike {
 
 case class ComputationStrategyRecord(
    strategyType: ComputationStrategyType.Value,
-   recompute: Boolean,
    sourceColumns: Option[Seq[MinimalColumnRecord]],
    parameters: Option[JObject])
 

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/wiremodels/ComputationStrategySpec.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/wiremodels/ComputationStrategySpec.scala
@@ -29,14 +29,12 @@ object SourceColumnSpec {
 /**
  * Defines how the value for a computed column is derived
  * @param strategyType Strategy used to compute the column value
- * @param recompute Whether the value should be recomputed every time the source columns are updated
  * @param sourceColumns Other columns in the dataset needed to compute the column value
  * @param parameters Additional custom parameters (expected contents depend on strategy type)
  */
 @JsonKeyStrategy(Strategy.Underscore)
 case class ComputationStrategySpec(
   strategyType: ComputationStrategyType.Value,
-  recompute: Boolean,
   sourceColumns: Option[Seq[SourceColumnSpec]],
   parameters: Option[JObject])
 
@@ -46,7 +44,6 @@ object ComputationStrategySpec {
 
 
 case class UserProvidedComputationStrategySpec(strategyType: Option[ComputationStrategyType.Value],
-                                               recompute: Option[Boolean],
                                                sourceColumns: Option[Seq[String]],
                                                parameters: Option[JObject])
 
@@ -55,11 +52,10 @@ object UserProvidedComputationStrategySpec extends UserProvidedSpec[UserProvided
     val cex = new ComputationStrategyExtractor(obj.fields)
     for {
       strategyType <- cex.strategyType
-      recompute <- cex.recompute
       sourceColumns <- cex.sourceColumns
       parameters <- cex.parameters
     } yield {
-      UserProvidedComputationStrategySpec(strategyType, recompute, sourceColumns, parameters)
+      UserProvidedComputationStrategySpec(strategyType, sourceColumns, parameters)
     }
   }
 
@@ -79,7 +75,6 @@ object UserProvidedComputationStrategySpec extends UserProvidedSpec[UserProvided
       }
       case _ => Extracted(None)
     }
-    def recompute = e[Boolean]("recompute")
     def sourceColumns = e[Seq[String]]("source_columns")
     def parameters = e[JObject]("parameters")
   }

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/wiremodels/ComputationStrategyType.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/wiremodels/ComputationStrategyType.scala
@@ -16,10 +16,20 @@ object ComputationStrategyType extends Enumeration {
   // For backwards compatibility. Superceded by georegion_match_on_point
   val GeoRegion = Value("georegion")
 
-  def userColumnAllowed(v: Value) = v == GeoCoding
+  def userColumnAllowed(v: Value) = userColumnAllowedSet.contains(v)
+
+  private val userColumnAllowedSet = Set(
+    GeoCoding
+  )
 
   // true if strategy type has a ComputationHandler in soda-fountain
-  def computeSynchronously(v: Value) = v != GeoCoding
+  def computeSynchronously(v: Value) = computeSynchronouslySet.contains(v)
+
+  private val computeSynchronouslySet = Set(
+    GeoRegionMatchOnPoint,
+    GeoRegionMatchOnString,
+    Test
+  )
 }
 
 object ComputationStrategyTypeCodec extends JsonEncode[ComputationStrategyType.Value] with JsonDecode[ComputationStrategyType.Value] {

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/wiremodels/ComputationStrategyType.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/wiremodels/ComputationStrategyType.scala
@@ -10,10 +10,16 @@ object ComputationStrategyType extends Enumeration {
 
   val GeoRegionMatchOnPoint = Value("georegion_match_on_point")
   val GeoRegionMatchOnString = Value("georegion_match_on_string")
+  val GeoCoding = Value("geocoding")
   val Test      = Value("test")
 
   // For backwards compatibility. Superceded by georegion_match_on_point
   val GeoRegion = Value("georegion")
+
+  def userColumnAllowed(v: Value) = v == GeoCoding
+
+  // true if strategy type has a ComputationHandler in soda-fountain
+  def computeSynchronously(v: Value) = v != GeoCoding
 }
 
 object ComputationStrategyTypeCodec extends JsonEncode[ComputationStrategyType.Value] with JsonDecode[ComputationStrategyType.Value] {

--- a/soda-fountain-lib/src/test/scala/com/socrata/datacoordinator/client/ColumnMutationTest.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/datacoordinator/client/ColumnMutationTest.scala
@@ -8,10 +8,10 @@ class ColumnMutationTest extends DataCoordinatorClientTest {
 
   val numberType = SoQLType.typesByName(TypeName("number"))
   val id = ColumnId("a column id")
-  val hint = "a hint"
+  val fieldName = ColumnName("a_field_name")
   test("Add Column toString produces JSON") {
-    val ac = new AddColumnInstruction(numberType, hint, Some(id))
-    ac.toString must equal (normalizeWhitespace("{c:'add column', hint:'a hint', type:'number', id:'a column id'}"))
+    val ac = new AddColumnInstruction(numberType, fieldName, Some(id), None)
+    ac.toString must equal (normalizeWhitespace("{c:'add column', field_name:'a_field_name', type:'number', id:'a column id'}"))
   }
   test("Drop Column toString produces JSON") {
     val ac = new DropColumnInstruction(id)

--- a/soda-fountain-lib/src/test/scala/com/socrata/soda/server/DatasetsForTesting.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/soda/server/DatasetsForTesting.scala
@@ -59,7 +59,6 @@ trait DatasetsForTesting {
 
     val computationStrategy = ComputationStrategyRecord(
       ComputationStrategyType.Test,
-      true,
       Some(Seq(MinimalColumnRecord(sourceColumn.id, sourceColumn.fieldName, SoQLNull, false, None))),
       Some(JObject(Map("concat_text" -> JString("fun")))))
 

--- a/soda-fountain-lib/src/test/scala/com/socrata/soda/server/computation/GeoregionMatchOnPointHandlerTest.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/soda/server/computation/GeoregionMatchOnPointHandlerTest.scala
@@ -54,7 +54,7 @@ trait GeoregionMatchOnPointHandlerData {
   }
 
   def computeStrategy(explicitPrimaryKeyParam: Boolean) = {
-    ComputationStrategyRecord(ComputationStrategyType.GeoRegionMatchOnPoint, false,
+    ComputationStrategyRecord(ComputationStrategyType.GeoRegionMatchOnPoint,
       Some(Seq(sourceColumn("geom-1234"))),
       Some(JObject(strategyParams(explicitPrimaryKeyParam))))
   }
@@ -287,7 +287,6 @@ class GeoregionMatchOnPointHandlerTest extends FunSuite
     when(badColumnSpec.computationStrategy).thenReturn(Some(
       ComputationStrategyRecord(
         ComputationStrategyType.GeoRegionMatchOnPoint,
-        false,
         Some(Seq(sourceColumn(""))),
         Some(JObject(Map())))))
 
@@ -302,7 +301,6 @@ class GeoregionMatchOnPointHandlerTest extends FunSuite
     when(badColumnSpec.computationStrategy).thenReturn(Some(
       ComputationStrategyRecord(
         ComputationStrategyType.GeoRegionMatchOnPoint,
-        false,
         Some(Seq()),
         null)))
 

--- a/soda-fountain-lib/src/test/scala/com/socrata/soda/server/computation/GeoregionMatchOnStringHandlerTest.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/soda/server/computation/GeoregionMatchOnStringHandlerTest.scala
@@ -50,7 +50,6 @@ class GeoregionMatchOnStringHandlerTest extends FunSuiteLike with FakeDiscovery 
     when(columnDef.computationStrategy).thenReturn(Some(
       ComputationStrategyRecord(
         ComputationStrategyType.GeoRegionMatchOnString,
-        true,
         Some(Seq(sourceColumn)),
         Some(JObject(Map("region" -> JString("sfo_zipcodes"),
                          "column" -> JString("zip"),
@@ -65,7 +64,6 @@ class GeoregionMatchOnStringHandlerTest extends FunSuiteLike with FakeDiscovery 
     when(columnDef.computationStrategy).thenReturn(Some(
       ComputationStrategyRecord(
         ComputationStrategyType.GeoRegionMatchOnString,
-        true,
         Some(Seq(sourceColumn)),
         None)))
 
@@ -80,7 +78,6 @@ class GeoregionMatchOnStringHandlerTest extends FunSuiteLike with FakeDiscovery 
     when(columnDef.computationStrategy).thenReturn(Some(
       ComputationStrategyRecord(
         ComputationStrategyType.GeoRegionMatchOnString,
-        true,
         Some(Seq(sourceColumn)),
         Some(JObject(Map("column" -> JString("zip"), "primary_key" -> JString("_feature_id")))))))
 
@@ -95,7 +92,6 @@ class GeoregionMatchOnStringHandlerTest extends FunSuiteLike with FakeDiscovery 
     when(columnDef.computationStrategy).thenReturn(Some(
       ComputationStrategyRecord(
         ComputationStrategyType.GeoRegionMatchOnString,
-        true,
         Some(Seq(sourceColumn)),
         Some(JObject(Map("region" -> JString("sfo_zipcodes"), "primary_key" -> JString("_feature_id")))))))
 
@@ -110,7 +106,6 @@ class GeoregionMatchOnStringHandlerTest extends FunSuiteLike with FakeDiscovery 
     when(columnDef.computationStrategy).thenReturn(Some(
       ComputationStrategyRecord(
         ComputationStrategyType.GeoRegionMatchOnString,
-        true,
         Some(Seq(sourceColumn)),
         Some(JObject(Map("region" -> JString("sfo_zipcodes"), "column" -> JString("zip")))))))
 

--- a/soda-fountain-lib/src/test/scala/com/socrata/soda/server/highlevel/ColumnSpecUtilsTest.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/soda/server/highlevel/ColumnSpecUtilsTest.scala
@@ -1,5 +1,6 @@
 package com.socrata.soda.server.highlevel
 
+import com.socrata.soda.server.wiremodels.{ComputationStrategyType, UserProvidedComputationStrategySpec}
 import org.scalatest.{FunSuite, Matchers}
 import java.security.SecureRandom
 import com.socrata.soql.environment.ColumnName
@@ -8,46 +9,50 @@ class ColumnSpecUtilsTest extends FunSuite with Matchers {
   lazy val rng = new scala.util.Random(new SecureRandom())
   lazy val columnSpecUtils = new ColumnSpecUtils(rng)
 
-  def test(columnName: String, isComputed: Boolean, expectValid: Boolean) =
-    columnSpecUtils.validColumnName(ColumnName(columnName), isComputed) should be (expectValid)
+  def test(columnName: String, uCompStrategy: Option[UserProvidedComputationStrategySpec], expectValid: Boolean) =
+    columnSpecUtils.validColumnName(ColumnName(columnName), uCompStrategy) should be (expectValid)
 
   test("validColumnName - non computed column, valid name") {
-    test("address", false, true)
+    test("address", None, true)
   }
 
   test("validColumnName - non computed column, :@ name") {
-    test(":@address", false, true)
+    test(":@address", None, true)
   }
 
   test("validColumnName - non computed column, blank name") {
-    test("", false, false)
+    test("", None, false)
   }
 
   test("validColumnName - non computed column, invalid chars") {
-    test("add,ress", false, false)
+    test("add,ress", None, false)
   }
 
   test("validColumnName - non computed column, underscore") {
-    test("add_ress", false, true)
+    test("add_ress", None, true)
   }
 
   test("validColumnName - non computed column, hyphen") {
-    test("add-ress", false, true)
+    test("add-ress", None, true)
   }
 
   test("validColumnName - non computed column, colon") {
-    test(":address", false, false)
+    test(":address", None, false)
   }
 
   test("validColumnName - computed column, colon") {
-    test(":location", true, true)
+    test(":location", Some(UserProvidedComputationStrategySpec(Some(ComputationStrategyType.Test), None, None)), true)
   }
 
-  test("validColumnName - computed column, no colon") {
-    test("location", true, false)
+  test("validColumnName - computed column, no colon allowed") {
+    test("location", Some(UserProvidedComputationStrategySpec(Some(ComputationStrategyType.GeoCoding), None, None)), true)
+  }
+
+  test("validColumnName - computed column, no colon not allowed") {
+    test("region", Some(UserProvidedComputationStrategySpec(Some(ComputationStrategyType.GeoRegionMatchOnPoint), None, None)), false)
   }
 
   test("validColumnName - computed column, collides with system column") {
-    test(":created_at", true, false)
+    test(":created_at",  Some(UserProvidedComputationStrategySpec(Some(ComputationStrategyType.Test), None, None)), false)
   }
 }

--- a/soda-fountain-lib/src/test/scala/com/socrata/soda/server/persistence/PostgresStoreTest.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/soda/server/persistence/PostgresStoreTest.scala
@@ -107,7 +107,6 @@ class PostgresStoreTest extends SodaFountainDatabaseTest with ShouldMatchers wit
         false,
         Some(ComputationStrategyRecord(
           ComputationStrategyType.GeoRegionMatchOnPoint,
-          true,
           Some(Seq(MinimalColumnRecord(ColumnId("abcd-1234"), ColumnName("location"), SoQLPoint, false, None))),
           Some(JObject(Map("georegion_resource_name" -> JString("chicago_wards"))))
         ))
@@ -127,14 +126,13 @@ class PostgresStoreTest extends SodaFountainDatabaseTest with ShouldMatchers wit
                         displayName,
                         description,
                         isInconsistencyResolutionGenerated,
-                        Some(ComputationStrategyRecord(strategy, recompute, Some(sourceColumns), Some(params)))) =>
+                        Some(ComputationStrategyRecord(strategy, Some(sourceColumns), Some(params)))) =>
         id should equal (columns(1).id)
         fieldName should equal (columns(1).fieldName)
         displayName should equal (columns(1).name)
         description should equal (columns(1).description)
         isInconsistencyResolutionGenerated should equal (columns(1).isInconsistencyResolutionGenerated)
         strategy should equal (columns(1).computationStrategy.get.strategyType)
-        recompute should equal (columns(1).computationStrategy.get.recompute)
         sourceColumns should equal (columns(1).computationStrategy.get.sourceColumns.get)
         params should equal (columns(1).computationStrategy.get.parameters.get)
     }

--- a/soda-fountain-lib/src/test/scala/com/socrata/soda/server/services/ComputationStrategyExtractorTest.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/soda/server/services/ComputationStrategyExtractorTest.scala
@@ -12,14 +12,12 @@ class ComputationStrategyExtractorTest extends FunSuite with Matchers {
   test("All fields populated") {
     val spec = extract("""{
                          |  type: "georegion_match_on_point",
-                         |  recompute: true,
                          |  source_columns: ["location"],
                          |  parameters: { georegion_uid:"abcd-1234" }
                          |}""".stripMargin)
     spec match {
       case Extracted(compStrategy) =>
         compStrategy.strategyType should be (Some(ComputationStrategyType.GeoRegionMatchOnPoint))
-        compStrategy.recompute should equal (Some(true))
         compStrategy.sourceColumns should be (Some(Seq("location")))
         compStrategy.parameters should be (Some(JObject(Map("georegion_uid" -> JString("abcd-1234")))))
 
@@ -29,14 +27,12 @@ class ComputationStrategyExtractorTest extends FunSuite with Matchers {
 
   test("No type") {
     val spec = extract("""{
-                         |  recompute: true,
                          |  source_columns: ["location"],
                          |  parameters: { georegion_uid:"abcd-1234" }
                          |}""".stripMargin)
     spec match {
       case Extracted(compStrategy) =>
         compStrategy.strategyType should be (None)
-        compStrategy.recompute should equal (Some(true))
         compStrategy.sourceColumns should be (Some(Seq("location")))
         compStrategy.parameters should be (Some(JObject(Map("georegion_uid" -> JString("abcd-1234")))))
       case _ => fail("didn't extract")
@@ -46,7 +42,6 @@ class ComputationStrategyExtractorTest extends FunSuite with Matchers {
   test("Bad type") {
     val spec = extract("""{
                             type: "giraffe",
-                         |  recompute: true,
                          |  source_columns: ["location"],
                          |  parameters: { georegion_uid:"abcd-1234" }
                          |}""".stripMargin)
@@ -65,7 +60,6 @@ class ComputationStrategyExtractorTest extends FunSuite with Matchers {
     spec match {
       case Extracted(compStrategy) =>
         compStrategy.strategyType should be (Some(ComputationStrategyType.GeoRegionMatchOnPoint))
-        compStrategy.recompute should be (None)
         compStrategy.sourceColumns should be (Some(Seq("location")))
         compStrategy.parameters should be (Some(JObject(Map("georegion_uid" -> JString("abcd-1234")))))
       case _ => fail("parsing should fail if recompute is missing")
@@ -75,13 +69,11 @@ class ComputationStrategyExtractorTest extends FunSuite with Matchers {
   test("No source columns") {
     val spec = extract("""{
                          |  type: "georegion_match_on_point",
-                         |  recompute: true,
                          |  parameters: { georegion_uid:"abcd-1234" }
                          |}""".stripMargin)
     spec match {
       case Extracted(compStrategy) =>
         compStrategy.strategyType should be (Some(ComputationStrategyType.GeoRegionMatchOnPoint))
-        compStrategy.recompute should equal (Some(true))
         compStrategy.sourceColumns should be (None)
         compStrategy.parameters should be (Some(JObject(Map("georegion_uid" -> JString("abcd-1234")))))
 
@@ -92,15 +84,30 @@ class ComputationStrategyExtractorTest extends FunSuite with Matchers {
   test("No parameters") {
     val spec = extract("""{
                          |  type: "georegion_match_on_point",
-                         |  recompute: true,
                          |  source_columns: ["location"]
                          |}""".stripMargin)
     spec match {
       case Extracted(compStrategy) =>
         compStrategy.strategyType should be (Some(ComputationStrategyType.GeoRegionMatchOnPoint))
-        compStrategy.recompute should equal (Some(true))
         compStrategy.sourceColumns should be (Some(Seq("location")))
         compStrategy.parameters should be (None)
+
+      case _ => fail("didn't extract")
+    }
+  }
+
+  test("Including depricated recompute field") {
+    val spec = extract("""{
+                         |  type: "georegion_match_on_point",
+                         |  recompute: true,
+                         |  source_columns: ["location"],
+                         |  parameters: { georegion_uid:"abcd-1234" }
+                         |}""".stripMargin)
+    spec match {
+      case Extracted(compStrategy) =>
+        compStrategy.strategyType should be (Some(ComputationStrategyType.GeoRegionMatchOnPoint))
+        compStrategy.sourceColumns should be (Some(Seq("location")))
+        compStrategy.parameters should be (Some(JObject(Map("georegion_uid" -> JString("abcd-1234")))))
 
       case _ => fail("didn't extract")
     }

--- a/soda-fountain-lib/src/test/scala/com/socrata/soda/server/services/DatasetExtractorTest.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/soda/server/services/DatasetExtractorTest.scala
@@ -72,7 +72,6 @@ class DatasetExtractorTest extends FunSuite with Matchers {
                          |    datatype: "number",
                          |    computation_strategy: {
                          |      type: "georegion_match_on_point",
-                         |      recompute: true,
                          |      source_columns: ["location"],
                          |      parameters: { georegion_uid:"abcd-1234" }
                          |    }}
@@ -92,7 +91,6 @@ class DatasetExtractorTest extends FunSuite with Matchers {
 
         val compStrategy = regionColumn.computationStrategy.get
         compStrategy.strategyType should be eq (Some(ComputationStrategyType.GeoRegionMatchOnPoint))
-        compStrategy.recompute should equal (Some(true))
         compStrategy.sourceColumns should be (Some(Seq("location")))
         compStrategy.parameters should be (Some(JObject(Map("georegion_uid" -> JString("abcd-1234")))))
 


### PR DESCRIPTION
 - Also passes on field `names
 - Makes computed columns with type "geocoding"
   not be named with ":@" so they are visible
 - Removes unused `recompute` column