### PR TITLE
aerust/EN-3506/part-2

### DIFF
--- a/soda-fountain-lib/src/main/resources/com/socrata/soda/server/persistence/pg/20160309-drop-recompute-from-computation-strategies.xml
+++ b/soda-fountain-lib/src/main/resources/com/socrata/soda/server/persistence/pg/20160309-drop-recompute-from-computation-strategies.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <changeSet author="Alexa Rust" id="20160309-drop-recompute-from-computation-strategies">
+        <dropColumn tableName="computation_strategies"
+                    columnName="recompute"/>
+    </changeSet>
+</databaseChangeLog>

--- a/soda-fountain-lib/src/main/resources/com/socrata/soda/server/persistence/pg/migrate.xml
+++ b/soda-fountain-lib/src/main/resources/com/socrata/soda/server/persistence/pg/migrate.xml
@@ -13,4 +13,5 @@
 
     <include file="com/socrata/soda/server/persistence/pg/21050724-add-deleted-at-column-multi-tables.xml"/>
     <include file="com/socrata/soda/server/persistence/pg/20160308-add-recompute-default-value.xml"/>
+    <include file="com/socrata/soda/server/persistence/pg/20160309-drop-recompute-from-computation-strategies.xml"/>
 </databaseChangeLog>

--- a/soda-fountain-lib/src/main/resources/com/socrata/soda/server/persistence/pg/sql/drop_recompute_from_computation_strategies.sql
+++ b/soda-fountain-lib/src/main/resources/com/socrata/soda/server/persistence/pg/sql/drop_recompute_from_computation_strategies.sql
@@ -1,2 +1,0 @@
-ALTER TABLE computation_strategies
-DROP COLUMN recompute;

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/persistence/pg/PostgresStoreImpl.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/persistence/pg/PostgresStoreImpl.scala
@@ -490,19 +490,18 @@ class PostgresStoreImpl(dataSource: DataSource) extends NameAndSchemaStore {
           csAdder.setString(1, datasetId.underlying)
           csAdder.setString(2, crec.id.underlying)
           csAdder.setString(3, cs.strategyType.toString)
-          csAdder.setBoolean(4, false)
           cs.sourceColumns match {
-            case Some(seq) => csAdder.setString(5, seq.mkString(","))
-            case None      => csAdder.setNull(5, Types.ARRAY)
+            case Some(seq) => csAdder.setString(4, seq.mkString(","))
+            case None      => csAdder.setNull(4, Types.ARRAY)
           }
-          csAdder.setString(6, datasetId.underlying)
-          csAdder.setLong(7, copyNumber)
+          csAdder.setString(5, datasetId.underlying)
+          csAdder.setLong(6, copyNumber)
           cs.parameters match {
-            case Some(jObj) => csAdder.setString(8, jObj.toString)
-            case None       => csAdder.setNull(8, Types.VARCHAR)
+            case Some(jObj) => csAdder.setString(7, jObj.toString)
+            case None       => csAdder.setNull(7, Types.VARCHAR)
           }
-          csAdder.setString(9, datasetId.underlying)
-          csAdder.setLong(10, copyNumber)
+          csAdder.setString(8, datasetId.underlying)
+          csAdder.setLong(9, copyNumber)
           csAdder.addBatch
         }
 
@@ -743,14 +742,12 @@ class PostgresStoreImpl(dataSource: DataSource) extends NameAndSchemaStore {
           |    dataset_system_id,
           |    column_id,
           |    computation_strategy_type,
-          |    recompute,
           |    source_columns,
           |    parameters,
           |    copy_id)
           |    SELECT dataset_system_id,
           |           column_id,
           |           computation_strategy_type,
-          |           recompute,
           |           source_columns,
           |           parameters,
           |           (SELECT id FROM dataset_copies WHERE dataset_system_id = ? And copy_number = ?)
@@ -856,12 +853,10 @@ object PostgresStoreImpl {
         (dataset_system_id,
          column_id,
          computation_strategy_type,
-         recompute,
          source_columns,
          parameters,
          copy_id)
          SELECT ?,
-                ?,
                 ?,
                 ?,
                 $compStrategySourceColumnPartialSql,


### PR DESCRIPTION
Drop recompute column only after all instances of
soda-fountain no longer reference the column.