### PR TITLE
EN-3506: Drop recompute column safely (part 1.25)

### DIFF
--- a/soda-fountain-lib/src/main/resources/com/socrata/soda/server/persistence/pg/20160308-add-recompute-default-value.xml
+++ b/soda-fountain-lib/src/main/resources/com/socrata/soda/server/persistence/pg/20160308-add-recompute-default-value.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <changeSet author="Alexa Rust" id="20160308-add-recompute-default-value">
+        <addDefaultValue tableName="computation_strategies"
+                         columnName="recompute"
+                         defaultValueBoolean="FALSE"/>
+    </changeSet>
+</databaseChangeLog>

--- a/soda-fountain-lib/src/main/resources/com/socrata/soda/server/persistence/pg/migrate.xml
+++ b/soda-fountain-lib/src/main/resources/com/socrata/soda/server/persistence/pg/migrate.xml
@@ -12,4 +12,5 @@
     <include file="com/socrata/soda/server/persistence/pg/20150501-add-missing-timezone.xml"/>
 
     <include file="com/socrata/soda/server/persistence/pg/21050724-add-deleted-at-column-multi-tables.xml"/>
+    <include file="com/socrata/soda/server/persistence/pg/20160308-add-recompute-default-value.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
Add default value for recompute column, so references
to it can be removed in the future.