### PR TITLE
Simplest possible geojson support for dataset with multiple geo columns

### DIFF
--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/export/Exporter.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/export/Exporter.scala
@@ -16,7 +16,6 @@ trait Exporter {
   def export(charset: AliasedCharset, schema: ExportDAO.CSchema,
              rows: Iterator[Array[SoQLValue]], singleRow: Boolean = false,
              obfuscateId: Boolean = true): HttpResponse
-  def validForSchema(schema: Seq[ColumnRecordLike]): Boolean = true
 }
 
 object Exporter {

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/export/GeoJsonExporter.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/export/GeoJsonExporter.scala
@@ -24,12 +24,6 @@ object GeoJsonExporter extends Exporter {
   val mimeType = new MimeType(mimeTypeBase)
   val extension = Some("geojson")
 
-  // For now, GeoJSON only works if you have at least ONE geo column in the dataset.
-  // Attempting to export a dataset with zero or more than one geo columns will return HTTP 406.
-  override def validForSchema(schema: Seq[ColumnRecordLike]): Boolean = {
-    schema.count(_.typ.isInstanceOf[SoQLGeometryLike[_]]) > 0
-  }
-
   def export(charset: AliasedCharset,
              schema: ExportDAO.CSchema,
              rows: Iterator[Array[SoQLValue]],
@@ -64,19 +58,22 @@ class GeoJsonProcessor(writer: BufferedWriter, schema: ExportDAO.CSchema, single
 
   val jsonWriter = new CompactJsonWriter(writer)
 
-  private def getGeoColumnIndex(columns: Seq[ColumnInfo]): Int = {
+  private def getGeoColumnIndex(columns: Seq[ColumnInfo]): Option[Int] = {
     val geoColumnIndices = columns.zipWithIndex.collect {
       case (columnInfo, index) if columnInfo.typ.isInstanceOf[SoQLGeometryLike[_]] => index
     }
 
-    if (geoColumnIndices.size == 0) throw InvalidGeoJsonSchema
-
-    // As a first step to supporting geojson export on datasets with multiple geo columns,
-    // we'll pick the first geo column we happened to encounter as the primary feature geometry.
-    // Other geometry column values will be relegated to the attributes section of the feature.
-    // Ideally we'd allow the API caller to pass a parameter indicating which column should be
-    // the primary geometry, but that's a bigger refactor that we haven't prioritized yet.
-    geoColumnIndices(0)
+    if (geoColumnIndices.size == 0) {
+      // There are no geometry columns on this dataset.
+      None
+    } else {
+      // As a first step to supporting geojson export on datasets with multiple geo columns,
+      // we'll pick the first geo column we happened to encounter as the primary feature geometry.
+      // Other geometry column values will be relegated to the attributes section of the feature.
+      // Ideally we'd allow the API caller to pass a parameter indicating which column should be
+      // the primary geometry, but that's a bigger refactor that we haven't prioritized yet.
+      Some(geoColumnIndices(0))
+    }
   }
 
   private def getGeometryJson(soqlGeom: SoQLValue): JValue =
@@ -92,12 +89,17 @@ class GeoJsonProcessor(writer: BufferedWriter, schema: ExportDAO.CSchema, single
     }
 
   private def writeGeoJsonRow(row: Array[SoQLValue]) {
-    val properties = row.zipWithIndex.filterNot(_._2 == geoColumnIndex).map { case (value, index) =>
+    val properties = row.zipWithIndex.filterNot(_._2 == geoColumnIndex.getOrElse(-1)).map { case (value, index) =>
       propertyNames(index) -> propertyReps(index).toJValue(value)
     }
 
+    val primaryGeometry = geoColumnIndex match {
+      case Some(idx) => getGeometryJson(row(idx))
+      case None      => JNull
+    }
+
     val map = Map("type"       -> JString("Feature"),
-                  "geometry"   -> getGeometryJson(row(geoColumnIndex)),
+                  "geometry"   -> primaryGeometry,
                   "properties" -> JObject(properties.toMap))
     val finalMap = if (singleRow) map + ("crs" -> JsonReader.fromString(wgs84ProjectionInfo)) else map
 

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/ExportDAO.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/ExportDAO.scala
@@ -43,7 +43,6 @@ trait ExportDAO {
   def retry() = throw new Retry
 
   def export[T](dataset: ResourceName,
-                schemaCheck: Seq[ColumnRecordLike] => Boolean,
                 precondition: Precondition,
                 copy: String,
                 param: ExportParam,

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/RowDAO.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/RowDAO.scala
@@ -32,7 +32,6 @@ trait RowDAO {
             resourceScope: ResourceScope): Result
 
   def getRow(dataset: ResourceName,
-             schemaCheck: Seq[ColumnRecord] => Boolean,
              precondition: Precondition,
              ifModifiedSince: Option[DateTime],
              rowId: RowSpecifier,

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/RowDAOImpl.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/RowDAOImpl.scala
@@ -51,7 +51,6 @@ class RowDAOImpl(store: NameAndSchemaStore, dc: DataCoordinatorClient, qc: Query
   }
 
   def getRow(resourceName: ResourceName,
-             schemaCheck: Seq[ColumnRecord] => Boolean,
              precondition: Precondition,
              ifModifiedSince: Option[DateTime],
              rowId: RowSpecifier,
@@ -63,47 +62,45 @@ class RowDAOImpl(store: NameAndSchemaStore, dc: DataCoordinatorClient, qc: Query
              resourceScope: ResourceScope): Result = {
     store.lookupDataset(resourceName, copy) match {
       case Some(datasetRecord) =>
-        if (schemaCheck(datasetRecord.columns)) {
-          val pkCol = datasetRecord.columnsById(datasetRecord.primaryKey)
-          val stringRep = StringColumnRep.forType(pkCol.typ)
-          stringRep.fromString(rowId.underlying) match {
-            case Some(soqlValue) =>
-              val soqlLiteralRep = SoQLLiteralColumnRep.forType(pkCol.typ)
-              val literal = soqlLiteralRep.toSoQLLiteral(soqlValue)
-              val query = s"select *, :version where `${pkCol.fieldName}` = $literal"
-              getRows(datasetRecord, NoPrecondition, ifModifiedSince, query, None, copy, secondaryInstance,
-                      noRollup, obfuscateId, requestId, resourceScope) match {
-                case QuerySuccess(_, truthVersion, truthLastModified, rollup, simpleSchema, rows) =>
-                  val version = ColumnName(":version")
-                  val versionPos = simpleSchema.schema.indexWhere(_.fieldName == version)
-                  val deVersionedSchema = simpleSchema.copy(schema = simpleSchema.schema.take(versionPos) ++ simpleSchema.schema.drop(versionPos + 1))
-                  val rowsStream = rows.toStream
-                  rowsStream.headOption match {
-                    case Some(rowWithVersion) if rowsStream.lengthCompare(1) == 0 =>
-                      val etag = StrongEntityTag(rowWithVersion(versionPos).toString.getBytes(StandardCharsets.UTF_8))
-                      val row = rowWithVersion.take(versionPos) ++ rowWithVersion.drop(versionPos + 1)
-                      precondition.check(Some(etag), sideEffectFree = true) match {
-                        case Precondition.Passed =>
-                          RowDAO.SingleRowQuerySuccess(Seq(etag), truthVersion, truthLastModified, deVersionedSchema, row)
-                        case f: Precondition.Failure =>
-                          RowDAO.PreconditionFailed(f)
-                      }
-                    case Some(rowWithVersion) =>
-                      TooManyRows
-                    case _ =>
-                      precondition.check(None, sideEffectFree = true) match {
-                        case Precondition.Passed =>
-                          RowDAO.RowNotFound(rowId)
-                        case f: Precondition.Failure =>
-                          RowDAO.PreconditionFailed(f)
-                      }
-                  }
-                case other =>
-                  other
-              }
-            case None => RowNotFound(rowId) // it's not a valid value and therefore trivially not found
-          }
-        } else SchemaInvalidForMimeType
+        val pkCol = datasetRecord.columnsById(datasetRecord.primaryKey)
+        val stringRep = StringColumnRep.forType(pkCol.typ)
+        stringRep.fromString(rowId.underlying) match {
+          case Some(soqlValue) =>
+            val soqlLiteralRep = SoQLLiteralColumnRep.forType(pkCol.typ)
+            val literal = soqlLiteralRep.toSoQLLiteral(soqlValue)
+            val query = s"select *, :version where `${pkCol.fieldName}` = $literal"
+            getRows(datasetRecord, NoPrecondition, ifModifiedSince, query, None, copy, secondaryInstance,
+                    noRollup, obfuscateId, requestId, resourceScope) match {
+              case QuerySuccess(_, truthVersion, truthLastModified, rollup, simpleSchema, rows) =>
+                val version = ColumnName(":version")
+                val versionPos = simpleSchema.schema.indexWhere(_.fieldName == version)
+                val deVersionedSchema = simpleSchema.copy(schema = simpleSchema.schema.take(versionPos) ++ simpleSchema.schema.drop(versionPos + 1))
+                val rowsStream = rows.toStream
+                rowsStream.headOption match {
+                  case Some(rowWithVersion) if rowsStream.lengthCompare(1) == 0 =>
+                    val etag = StrongEntityTag(rowWithVersion(versionPos).toString.getBytes(StandardCharsets.UTF_8))
+                    val row = rowWithVersion.take(versionPos) ++ rowWithVersion.drop(versionPos + 1)
+                    precondition.check(Some(etag), sideEffectFree = true) match {
+                      case Precondition.Passed =>
+                        RowDAO.SingleRowQuerySuccess(Seq(etag), truthVersion, truthLastModified, deVersionedSchema, row)
+                      case f: Precondition.Failure =>
+                        RowDAO.PreconditionFailed(f)
+                    }
+                  case Some(rowWithVersion) =>
+                    TooManyRows
+                  case _ =>
+                    precondition.check(None, sideEffectFree = true) match {
+                      case Precondition.Passed =>
+                        RowDAO.RowNotFound(rowId)
+                      case f: Precondition.Failure =>
+                        RowDAO.PreconditionFailed(f)
+                    }
+                }
+              case other =>
+                other
+            }
+          case None => RowNotFound(rowId) // it's not a valid value and therefore trivially not found
+        }
       case None =>
         DatasetNotFound(resourceName)
     }

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/ComputeUtils.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/ComputeUtils.scala
@@ -74,7 +74,6 @@ class ComputeUtils(columnDAO: ColumnDAO, exportDAO: ExportDAO, rowDAO: RowDAO, c
         log.info("export dataset {} for column compute", dataset.resourceName.name)
         val param = ExportParam(None, None, columns, None, sorted = false, rowId = None)
         exportDAO.export(dataset.resourceName,
-                         JsonExporter.validForSchema,
                          NoPrecondition,
                          "latest",
                          param,

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/Export.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/Export.scala
@@ -171,7 +171,6 @@ case class Export(exportDAO: ExportDAO, etagObfuscator: ETagObfuscator) {
           case Some((mimeType, charset, language)) =>
             val exporter = Exporter.exportForMimeType(mimeType)
             exportDAO.export(resourceName,
-                             exporter.validForSchema,
                              passOnPrecondition,
                              copy,
                              param,

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/Resource.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/Resource.scala
@@ -306,7 +306,6 @@ case class Resource(rowDAO: RowDAO,
                 using(new ResourceScope) { resourceScope =>
                   rowDAO.getRow(
                     resourceName,
-                    exporter.validForSchema,
                     newPrecondition.map(_.dropRight(suffix.length)),
                     req.dateTimeHeader("If-Modified-Since"),
                     rowId,

--- a/soda-fountain-lib/src/test/scala/com/socrata/soda/server/metrics/QueryMetricTest.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/soda/server/metrics/QueryMetricTest.scala
@@ -248,7 +248,7 @@ private class QueryOnlyRowDAO(testDatasets: Set[TestDataset]) extends RowDAO {
             reqId: String, rs: ResourceScope): Result = {
     testDatasets.find(_.resource == dataset).map(_.getResult).getOrElse(throw new Exception("TestDataset not defined"))
   }
-  def getRow(dataset: ResourceName, schemaCheck: (Seq[ColumnRecord]) => Boolean, precondition: Precondition, ifModifiedSince: Option[DateTime], rowId: RowSpecifier,
+  def getRow(dataset: ResourceName, precondition: Precondition, ifModifiedSince: Option[DateTime], rowId: RowSpecifier,
              stage: Option[Stage], secondaryInstance: Option[String], noRollup: Boolean, obfuscateId: Boolean,
              reqId: String, rs: ResourceScope): Result = {
     query(dataset, precondition, ifModifiedSince, "give me one row!", None, None, secondaryInstance, noRollup, obfuscateId,


### PR DESCRIPTION
When originally implementing geojson, we completely locked down geojson export on datasets with multiple geo columns, however we've had a decent number of requests to support this scenario and it seems to make sense to loosen these restrictions somewhat.

As an initial step, the exporter picks the first geo column it happens to encounter as the primary feature geometry. Other geometry column values will be relegated to the attributes section of the feature. 

Ideally we'd allow the API caller to pass a parameter indicating which column should be the primary geometry, but that's a bigger refactor that we haven't prioritized yet.