### PR TITLE
EN-3506: Drop recompute column safely (part 2)

### DIFF
--- a/soda-fountain-lib/src/main/resources/com/socrata/soda/server/persistence/pg/20160309-drop-recompute-from-computation-strategies.xml
+++ b/soda-fountain-lib/src/main/resources/com/socrata/soda/server/persistence/pg/20160309-drop-recompute-from-computation-strategies.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <changeSet author="Alexa Rust" id="20160309-drop-recompute-from-computation-strategies">
+        <dropColumn tableName="computation_strategies"
+                    columnName="recompute"/>
+    </changeSet>
+</databaseChangeLog>

--- a/soda-fountain-lib/src/main/resources/com/socrata/soda/server/persistence/pg/migrate.xml
+++ b/soda-fountain-lib/src/main/resources/com/socrata/soda/server/persistence/pg/migrate.xml
@@ -13,4 +13,5 @@
 
     <include file="com/socrata/soda/server/persistence/pg/21050724-add-deleted-at-column-multi-tables.xml"/>
     <include file="com/socrata/soda/server/persistence/pg/20160308-add-recompute-default-value.xml"/>
+    <include file="com/socrata/soda/server/persistence/pg/20160309-drop-recompute-from-computation-strategies.xml"/>
 </databaseChangeLog>

--- a/soda-fountain-lib/src/main/resources/com/socrata/soda/server/persistence/pg/sql/drop_recompute_from_computation_strategies.sql
+++ b/soda-fountain-lib/src/main/resources/com/socrata/soda/server/persistence/pg/sql/drop_recompute_from_computation_strategies.sql
@@ -1,2 +1,0 @@
-ALTER TABLE computation_strategies
-DROP COLUMN recompute;


### PR DESCRIPTION
Drop recompute column only after all instances of
soda-fountain no longer reference the column.

-- Must be in a seperate release from commit
c1553f284b9fa4e6a6ee3b20a79b04722617c539
--