### PR TITLE
EN-6972: Not all non-200 responses are errors!

### DIFF
--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/SodaRouter.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/SodaRouter.scala
@@ -5,7 +5,7 @@ import com.socrata.http.server.routing.SimpleRouteContext._
 import com.socrata.http.server.routing.{OptionallyTypedPathComponent, Extractor}
 import com.socrata.http.server.{HttpRequest, HttpService, HttpResponse}
 import com.socrata.soda.server._
-import com.socrata.soda.server.errors.GeneralNotFoundError
+import com.socrata.soda.server.responses.GeneralNotFoundError
 import com.socrata.soda.server.id.{RollupName, RowSpecifier, SecondaryId, ResourceName}
 import com.socrata.soql.environment.ColumnName
 
@@ -94,7 +94,7 @@ class SodaRouter(versionResource: HttpService,
       case Some(s) =>
         s(req)
       case None =>
-        SodaUtils.errorResponse(req, GeneralNotFoundError(req.getRequestURI))
+        SodaUtils.response(req, GeneralNotFoundError(req.getRequestURI))
     }
   }
 }

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/Dataset.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/Dataset.scala
@@ -7,7 +7,7 @@ import com.socrata.http.server.responses._
 import com.socrata.http.server.util.RequestId
 import com.socrata.soda.server._
 import com.socrata.soda.server.copy.Stage
-import com.socrata.soda.server.errors._
+import com.socrata.soda.server.responses._
 import com.socrata.soda.server.highlevel.DatasetDAO.{NonExistentColumn, DatasetAlreadyExists}
 import com.socrata.soda.server.highlevel._
 import com.socrata.soda.server.highlevel.DatasetDAO
@@ -29,7 +29,7 @@ case class Dataset(datasetDAO: DatasetDAO, maxDatumSize: Int) {
       case Extracted(datasetSpec) =>
         f(datasetSpec)
       case RequestProblem(err) =>
-        SodaUtils.errorResponse(request, err, logTags : _*)
+        SodaUtils.response(request, err, logTags : _*)
       case IOProblem(err) =>
         SodaUtils.internalError(request, err)
     }
@@ -40,7 +40,7 @@ case class Dataset(datasetDAO: DatasetDAO, maxDatumSize: Int) {
       case Extracted(datasetSpec) =>
         f(datasetSpec)
       case RequestProblem(err) =>
-        SodaUtils.errorResponse(request, err, logTags : _*)
+        SodaUtils.response(request, err, logTags : _*)
       case IOProblem(err) =>
         SodaUtils.internalError(request, err)
     }
@@ -79,31 +79,31 @@ case class Dataset(datasetDAO: DatasetDAO, maxDatumSize: Int) {
         NoContent
       // fail cases
       case DatasetDAO.DatasetAlreadyExists(dataset) =>
-        SodaUtils.errorResponse(req, DatasetAlreadyExistsSodaErr(dataset))
+        SodaUtils.response(req, DatasetAlreadyExistsSodaErr(dataset))
       case DatasetDAO.NonExistentColumn(dataset, column) =>
-        SodaUtils.errorResponse(req, ColumnNotFound(dataset, column))
+        SodaUtils.response(req, ColumnNotFound(dataset, column))
       case DatasetDAO.LocaleChanged(locale) =>
-        SodaUtils.errorResponse(req, LocaleChangedError(locale))
+        SodaUtils.response(req, LocaleChangedError(locale))
       case DatasetDAO.DatasetNotFound(dataset) =>
-        SodaUtils.errorResponse(req, DatasetNotFound(dataset))
+        SodaUtils.response(req, DatasetNotFound(dataset))
       case DatasetDAO.InvalidDatasetName(name) =>
-        SodaUtils.errorResponse(req, DatasetNameInvalidNameSodaErr(name))
+        SodaUtils.response(req, DatasetNameInvalidNameSodaErr(name))
       case DatasetDAO.RollupNotFound(name) =>
-        SodaUtils.errorResponse(req, RollupNotFound(name))
+        SodaUtils.response(req, RollupNotFound(name))
       case DatasetDAO.RollupError(reason) =>
-        SodaUtils.errorResponse(req, RollupCreationFailed(reason))
+        SodaUtils.response(req, RollupCreationFailed(reason))
       case DatasetDAO.RollupColumnNotFound(column) =>
-        SodaUtils.errorResponse(req, RollupColumnNotFound(column))
+        SodaUtils.response(req, RollupColumnNotFound(column))
       case DatasetDAO.CannotAcquireDatasetWriteLock(dataset) =>
-        SodaUtils.errorResponse(req, DatasetWriteLockError(dataset))
+        SodaUtils.response(req, DatasetWriteLockError(dataset))
       case DatasetDAO.FeedbackInProgress(dataset, stores) =>
-        SodaUtils.errorResponse(req, FeedbackInProgressError(dataset, stores))
+        SodaUtils.response(req, FeedbackInProgressError(dataset, stores))
       case DatasetDAO.UnsupportedUpdateOperation(message) =>
-        SodaUtils.errorResponse(req, UnsupportedUpdateOperation(message))
+        SodaUtils.response(req, UnsupportedUpdateOperation(message))
       case DatasetDAO.InternalServerError(code, tag, data) =>
-        SodaUtils.errorResponse(req, InternalError(tag, "code"  -> JString(code), "data" -> JString(data)))
+        SodaUtils.response(req, InternalError(tag, "code"  -> JString(code), "data" -> JString(data)))
       case DatasetDAO.UnexpectedInternalServerResponse(reason, tag) =>
-        SodaUtils.errorResponse(req, InternalError(tag, "reason"  -> JString(reason)))
+        SodaUtils.response(req, InternalError(tag, "reason"  -> JString(reason)))
 
     }
   }

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/Snapshots.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/Snapshots.scala
@@ -2,7 +2,7 @@ package com.socrata.soda.server.resources
 
 import com.socrata.http.server.HttpRequest
 import com.socrata.soda.server.SodaUtils
-import com.socrata.soda.server.errors.{SnapshotNotFound, DatasetNotFound}
+import com.socrata.soda.server.responses.{SnapshotNotFound, DatasetNotFound}
 import com.socrata.soda.server.highlevel.SnapshotDAO
 import com.socrata.soda.server.id.ResourceName
 import com.socrata.http.server.responses._
@@ -22,7 +22,7 @@ case class Snapshots(snapshotDAO: SnapshotDAO) {
         case Some(snapshots) =>
           OK ~> Json(snapshots)
         case None =>
-          SodaUtils.errorResponse(req.servletRequest, DatasetNotFound(resourceName))
+          SodaUtils.response(req.servletRequest, DatasetNotFound(resourceName))
       }
     }
   }
@@ -31,9 +31,9 @@ case class Snapshots(snapshotDAO: SnapshotDAO) {
     override def get = { (req: HttpRequest) =>
       snapshotDAO.exportSnapshot(resourceName, number, req.resourceScope) match {
         case SnapshotDAO.DatasetNotFound =>
-          SodaUtils.errorResponse(req.servletRequest, DatasetNotFound(resourceName))
+          SodaUtils.response(req.servletRequest, DatasetNotFound(resourceName))
         case SnapshotDAO.SnapshotNotFound =>
-          SodaUtils.errorResponse(req.servletRequest, SnapshotNotFound(resourceName, number))
+          SodaUtils.response(req.servletRequest, SnapshotNotFound(resourceName, number))
         case SnapshotDAO.Export(csv) =>
           OK ~> csv
       }
@@ -42,9 +42,9 @@ case class Snapshots(snapshotDAO: SnapshotDAO) {
     override def delete = { (req: HttpRequest) =>
       snapshotDAO.deleteSnapshot(resourceName, number) match {
         case SnapshotDAO.DatasetNotFound =>
-          SodaUtils.errorResponse(req.servletRequest, DatasetNotFound(resourceName))
+          SodaUtils.response(req.servletRequest, DatasetNotFound(resourceName))
         case SnapshotDAO.SnapshotNotFound =>
-          SodaUtils.errorResponse(req.servletRequest, SnapshotNotFound(resourceName, number))
+          SodaUtils.response(req.servletRequest, SnapshotNotFound(resourceName, number))
         case SnapshotDAO.Deleted =>
           OK
       }

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/SodaResource.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/SodaResource.scala
@@ -6,14 +6,14 @@ import com.socrata.http.server.implicits._
 import com.socrata.http.server.responses._
 import com.socrata.soda.server._
 import com.socrata.soda.server.SodaUtils
-import com.socrata.soda.server.errors.HttpMethodNotAllowed
+import com.socrata.soda.server.responses.HttpMethodNotAllowed
 import org.apache.commons.codec.binary.Base64
 
 class SodaResource extends SimpleResource {
 
   override def methodNotAllowed: HttpService = { req =>
     val allowed = allowedMethods
-    Header("Allow", allowed.mkString(",")) ~> SodaUtils.errorResponse(
+    Header("Allow", allowed.mkString(",")) ~> SodaUtils.response(
       req,
       HttpMethodNotAllowed(req.getMethod, allowed))
   }

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/Suggest.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/Suggest.scala
@@ -10,12 +10,12 @@ import com.socrata.http.client.exceptions.{ConnectFailed, ConnectTimeout, Conten
 import com.socrata.http.server._
 import com.socrata.http.server.implicits._
 import com.socrata.http.server.responses._
-import com.socrata.soda.server.SodaUtils.errorResponse
+import com.socrata.soda.server.SodaUtils.response
 import com.socrata.soda.server.config.SuggestConfig
 import com.socrata.soda.server.copy.{Published, Stage}
 import com.socrata.soda.server.highlevel.{ColumnDAO, DatasetDAO}
 import com.socrata.soda.server.id.ResourceName
-import com.socrata.soda.server.{errors => SodaError}
+import com.socrata.soda.server.{responses => SodaError}
 import com.socrata.soql.environment.ColumnName
 import com.socrata.thirdparty.metrics.Metrics
 
@@ -64,7 +64,7 @@ case class Suggest(datasetDao: DatasetDAO, columnDao: ColumnDAO,
     def err(e: Throwable): HttpResponse = {
       val tag = UUID.randomUUID().toString
       log.error("Unexpected error talking to spandex, tag {}", tag: Any, e)
-      errorResponse(com.socrata.soda.server.toServletHttpRequest(req), SodaError.InternalException(e, tag))
+      response(com.socrata.soda.server.toServletHttpRequest(req), SodaError.InternalException(e, tag))
     }
     internalContext(resourceName, columnName) match {
       case None => NotFound(resp)

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/UpsertUtils.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/UpsertUtils.scala
@@ -5,7 +5,7 @@ import com.rojoma.json.v3.io.CompactJsonWriter
 import com.rojoma.simplearm.util._
 import com.socrata.http.server.HttpRequest
 import com.socrata.soda.clients.datacoordinator.DataCoordinatorClient.{OtherReportItem, UpsertReportItem, ReportItem}
-import com.socrata.soda.server.{errors => SodaErrors, _}
+import com.socrata.soda.server.{responses => SodaErrors, _}
 import com.socrata.soda.server.id.ResourceName
 import com.socrata.soda.server.persistence.ColumnRecordLike
 import com.socrata.soda.server.highlevel.{ExportParam, RowDataTranslator, RowDAO}
@@ -46,30 +46,30 @@ object UpsertUtils {
       case RowDAO.StreamSuccess(report) =>
         successHandler(response, report)
       case mismatch : MaltypedData =>
-        SodaUtils.errorResponse(request, new SodaErrors.ColumnSpecMaltyped(mismatch.column.name, mismatch.expected.name.name, mismatch.got))(response)
+        SodaUtils.response(request, new SodaErrors.ColumnSpecMaltyped(mismatch.column.name, mismatch.expected.name.name, mismatch.got))(response)
       case RowDAO.RowNotFound(rowSpecifier) =>
-        SodaUtils.errorResponse(request, SodaErrors.RowNotFound(rowSpecifier))(response)
+        SodaUtils.response(request, SodaErrors.RowNotFound(rowSpecifier))(response)
       case RowDAO.RowPrimaryKeyIsNonexistentOrNull(rowSpecifier) =>
-        SodaUtils.errorResponse(request, SodaErrors.RowPrimaryKeyNonexistentOrNull(rowSpecifier))(response)
+        SodaUtils.response(request, SodaErrors.RowPrimaryKeyNonexistentOrNull(rowSpecifier))(response)
       case RowDAO.UnknownColumn(columnName) =>
-        SodaUtils.errorResponse(request, SodaErrors.RowColumnNotFound(columnName))(response)
+        SodaUtils.response(request, SodaErrors.RowColumnNotFound(columnName))(response)
       case RowDAO.ComputationHandlerNotFound(typ) =>
-        SodaUtils.errorResponse(request, SodaErrors.ComputationHandlerNotFound(typ))(response)
+        SodaUtils.response(request, SodaErrors.ComputationHandlerNotFound(typ))(response)
       case RowDAO.CannotDeletePrimaryKey =>
-        SodaUtils.errorResponse(request, SodaErrors.CannotDeletePrimaryKey)(response)
+        SodaUtils.response(request, SodaErrors.CannotDeletePrimaryKey)(response)
       case RowDAO.RowNotAnObject(obj) =>
-        SodaUtils.errorResponse(request, SodaErrors.UpsertRowNotAnObject(obj))(response)
+        SodaUtils.response(request, SodaErrors.UpsertRowNotAnObject(obj))(response)
       case RowDAO.DatasetNotFound(dataset) =>
-        SodaUtils.errorResponse(request, SodaErrors.DatasetNotFound(dataset))(response)
+        SodaUtils.response(request, SodaErrors.DatasetNotFound(dataset))(response)
       case RowDAO.SchemaOutOfSync =>
-        SodaUtils.errorResponse(request, SodaErrors.SchemaInvalidForMimeType)(response)
+        SodaUtils.response(request, SodaErrors.SchemaInvalidForMimeType)(response)
       case RowDAO.InvalidRequest(client, status, body) =>
-        SodaUtils.errorResponse(request, SodaErrors.InternalError(s"Error from $client:", "code"  -> JNumber(status),
+        SodaUtils.response(request, SodaErrors.InternalError(s"Error from $client:", "code"  -> JNumber(status),
           "data" -> body))(response)
       case RowDAO.QCError(status, qcErr) =>
-        SodaUtils.errorResponse(request, SodaErrors.ErrorReportedByQueryCoordinator(status, qcErr))(response)
+        SodaUtils.response(request, SodaErrors.ErrorReportedByQueryCoordinator(status, qcErr))(response)
       case RowDAO.InternalServerError(status, client, code, tag, data) =>
-        SodaUtils.errorResponse(request, SodaErrors.InternalError(s"Error from $client:",
+        SodaUtils.response(request, SodaErrors.InternalError(s"Error from $client:",
           "status" -> JNumber(status),
           "code"  -> JString(code),
           "data" -> JString(data),
@@ -132,19 +132,19 @@ object UpsertUtils {
                       exportSingleRowUpsertResponse(rowId.toString())
                     case unknown =>
                       log.error("single row upsert error, malformed report-item-id {}", unknown)
-                      SodaUtils.errorResponse(req,
+                      SodaUtils.response(req,
                         SodaErrors.InternalError("upsert-error-malformed-report-item-id"))(response)
                   }
                 case unknown =>
                   log.error("single row upsert error, malformed report-item {}", unknown)
-                  SodaUtils.errorResponse(req,
+                  SodaUtils.response(req,
                     SodaErrors.InternalError("upsert-error-malformed-report-item"))(response)
               }
             }
           }
         case OtherReportItem => // nothing; probably shouldn't have occurred!
           log.error("single row upsert error, got other-report-item")
-          SodaUtils.errorResponse(req,
+          SodaUtils.response(req,
             SodaErrors.InternalError("upsert-error-malformed-other-report-item"))(response)
       }
     }

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/responses/SodaResponse.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/responses/SodaResponse.scala
@@ -1,4 +1,4 @@
-package com.socrata.soda.server.errors
+package com.socrata.soda.server.responses
 
 import javax.servlet.http.HttpServletResponse
 
@@ -8,15 +8,15 @@ import com.socrata.http.server.util.EntityTag
 
 import scala.{collection => sc}
 
-abstract class SodaError(val httpResponseCode: Int, val errorCode: String, val message: String, val data: Map[String, JValue]) {
-  def this(httpResponseCode: Int, errorCode: String, message: String, data: (String, JValue)*) =
-    this(httpResponseCode, errorCode, message, data.foldLeft(Map.empty[String, JValue]) { (acc, kv) =>
+abstract class SodaResponse(val httpResponseCode: Int, val responseCode: String, val message: String, val data: Map[String, JValue]) {
+  def this(httpResponseCode: Int, responseCode: String, message: String, data: (String, JValue)*) =
+    this(httpResponseCode, responseCode, message, data.foldLeft(Map.empty[String, JValue]) { (acc, kv) =>
       assert(!acc.contains(kv._1), "Data field " + kv + " defined twice")
       acc + kv
     })
 
-  def this(errorCode: String, message: String, data: (String, JValue)*) =
-    this(HttpServletResponse.SC_BAD_REQUEST, errorCode, message: String, data: _*)
+  def this(responseCode: String, message: String, data: (String, JValue)*) =
+    this(HttpServletResponse.SC_BAD_REQUEST, responseCode, message: String, data: _*)
 
   def etags: Seq[EntityTag] = Nil
 
@@ -25,14 +25,14 @@ abstract class SodaError(val httpResponseCode: Int, val errorCode: String, val m
   // Some responses, such as NotModified, cannot have content according to HTTP 1.1
   def hasContent: Boolean = true
 
-  def humanReadableMessage: String = SodaError.translate(errorCode, message, sanitizedData)
+  def humanReadableMessage: String = SodaResponse.translate(responseCode, message, sanitizedData)
 
   def sanitizedData: Map[String, JValue] = data -- excludedFields
 
   def excludedFields: Set[String] = Set.empty
 }
 
-object SodaError {
+object SodaResponse {
   // errcode gets separately logged in soda-fountain, core, and di2. message also incorporates appropriate things in data right now.
-  def translate(errcode: String, message: String, data: sc.Map[String, JValue]): String = message
+  def translate(responseCode: String, message: String, data: sc.Map[String, JValue]): String = message
 }

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/responses/responses.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/responses/responses.scala
@@ -1,4 +1,4 @@
-package com.socrata.soda.server.errors
+package com.socrata.soda.server.responses
 
 import javax.activation.MimeType
 import javax.servlet.http.HttpServletResponse._
@@ -14,23 +14,23 @@ import com.socrata.soql.environment.{ColumnName, TypeName}
 case class ResourceNotModified(override val etags: Seq[EntityTag],
                                override val vary: Option[String],
                                override val hasContent: Boolean = false)
-  extends SodaError(SC_NOT_MODIFIED, "not-modified", "Resource was not modified")
+  extends SodaResponse(SC_NOT_MODIFIED, "not-modified", "Resource was not modified")
 
 case object EtagPreconditionFailed
-  extends SodaError(SC_PRECONDITION_FAILED, "precondition-failed", "Precondition failed")
+  extends SodaResponse(SC_PRECONDITION_FAILED, "precondition-failed", "Precondition failed")
 
 case object SchemaInvalidForMimeType
-  extends SodaError(SC_NOT_ACCEPTABLE, "schema-invalid-for-mime-type", "Schema is invalid for given mime-type")
+  extends SodaResponse(SC_NOT_ACCEPTABLE, "schema-invalid-for-mime-type", "Schema is invalid for given mime-type")
 
 case class GeneralNotFoundError(path: String)
-  extends SodaError(SC_NOT_FOUND, "not-found", s"Path not found: $path", "path" -> JString(path))
+  extends SodaResponse(SC_NOT_FOUND, "not-found", s"Path not found: $path", "path" -> JString(path))
 
 case class InternalError(tag: String, additionalData: (String, JValue)*)
-  extends SodaError(SC_INTERNAL_SERVER_ERROR, "internal-error", s"Internal error: $tag; $additionalData",
+  extends SodaResponse(SC_INTERNAL_SERVER_ERROR, "internal-error", s"Internal error: $tag; $additionalData",
                     Map("tag" -> JString(tag)) ++ additionalData)
 
 case class InternalException(th: Throwable, tag: String)
-  extends SodaError(SC_INTERNAL_SERVER_ERROR, "internal-error",
+  extends SodaResponse(SC_INTERNAL_SERVER_ERROR, "internal-error",
     s"Internal error: please include code $tag if you report the error",
     "tag"          -> JString(tag),
     "errorMessage" -> JString(Option(th.getMessage).getOrElse("")),
@@ -41,213 +41,213 @@ case class InternalException(th: Throwable, tag: String)
 }
 
 case class HttpMethodNotAllowed(method: String, allowed: TraversableOnce[String])
-  extends SodaError(SC_METHOD_NOT_ALLOWED, "method-not-allowed",
+  extends SodaResponse(SC_METHOD_NOT_ALLOWED, "method-not-allowed",
     s"HTTP method $method is not allowed for this request",
     "method" -> JString(method),
     "allowed" -> JsonEncode.toJValue(allowed.toSeq))
 
-case object NoContentType extends SodaError("req.content-type.missing", "No content-type is set on the request")
+case object NoContentType extends SodaResponse("req.content-type.missing", "No content-type is set on the request")
 
 // TODO change description to not use getOrElse when we make it non-optional
 case class ErrorReportedByQueryCoordinator(code: Int, value: QueryCoordinatorError)
-  extends SodaError(code, value.errorCode, s"Query coordinator error: ${value.errorCode}; ${value.description.getOrElse(value.errorCode)}", value.data)
+  extends SodaResponse(code, value.errorCode, s"Query coordinator error: ${value.errorCode}; ${value.description.getOrElse(value.errorCode)}", value.data)
 
 case class UnparsableContentType(contentType: String)
-  extends SodaError("req.content-type.unparsable", s"The content-type set on the request ($contentType) is unparseable",
+  extends SodaResponse("req.content-type.unparsable", s"The content-type set on the request ($contentType) is unparseable",
     "content-type" -> JString(contentType))
 
 case class ContentTypeNotJson(contentType: MimeType)
-  extends SodaError(SC_UNSUPPORTED_MEDIA_TYPE, "req.content-type.not-json",
+  extends SodaResponse(SC_UNSUPPORTED_MEDIA_TYPE, "req.content-type.not-json",
     s"The content-type set on the request (${contentType.toString}) should instead be of type 'application/json'",
     "content-type" -> JString(contentType.toString))
 
 case class ContentTypeUnsupportedCharset(contentType: MimeType)
-  extends SodaError(SC_UNSUPPORTED_MEDIA_TYPE, "req.content-type.unknown-charset",
+  extends SodaResponse(SC_UNSUPPORTED_MEDIA_TYPE, "req.content-type.unknown-charset",
     s"The content-type set on the request (${contentType.toString}) has an unsupported charset",
     "content-type" -> JString(contentType.toString))
 
 case class MalformedJsonBody(row: Int, column: Int)
-  extends SodaError("req.body.malformed-json", s"The json request body is malformed at row $row and column $column",
+  extends SodaResponse("req.body.malformed-json", s"The json request body is malformed at row $row and column $column",
     "row" -> JNumber(row),
     "column" -> JNumber(column))
 
 case class BodyTooLarge(limit: Long)
-  extends SodaError(SC_REQUEST_ENTITY_TOO_LARGE, "req.body.too-large",
+  extends SodaResponse(SC_REQUEST_ENTITY_TOO_LARGE, "req.body.too-large",
     s"The request body is too large; the limit is $limit bytes",
     "limit" -> JNumber(limit))
 
 case class ContentNotSingleObject(value: JValue)
-  extends SodaError("req.content.json.not-object",
+  extends SodaResponse("req.content.json.not-object",
     s"The json content of the request contains an unreadable object ($value)",
     "value" -> value)
 
 case class InvalidJsonContent(expected: String)
-  extends SodaError("req.content.json.invalid",
+  extends SodaResponse("req.content.json.invalid",
     s"The json content of the request is not an array or object",
     "expected" -> JString(expected))
 
 case class DatasetSpecMaltyped(field: String, expected: String, got: JValue)
-  extends SodaError("soda.dataset.maltyped",
+  extends SodaResponse("soda.dataset.maltyped",
     s"Dataset is maltyped; for field '$field' we expected '$expected' but got '$got'",
     "field" -> JString(field),
     "expected" -> JString(expected),
     "got" -> got)
 
 case class ColumnSpecMaltyped(field: String, expected: String, got: JValue)
-  extends SodaError("soda.column.maltyped",
+  extends SodaResponse("soda.column.maltyped",
     s"Column is maltyped; for field '$field' we expected '$expected' but got '$got'",
     "field" -> JString(field),
     "expected" -> JString(expected),
     "got" -> got)
 
 case class ComputationStrategySpecMaltyped(field: String, expected: String, got: JValue)
-  extends SodaError("soda.column_computation_strategy.maltyped",
+  extends SodaResponse("soda.column_computation_strategy.maltyped",
     s"Column computation strategy is maltyped; for field '$field' we expected '$expected' but got '$got'",
     "field" -> JString(field),
     "expected" -> JString(expected),
     "got" -> got)
 
 case class ComputationStrategySpecUnknownType(typ: String)
-  extends SodaError("soda.computation-strategy.unknown-type",
+  extends SodaResponse("soda.computation-strategy.unknown-type",
     s"The specified computation strategy type ($typ) is unknown",
     "type" -> JString(typ))
 
 case class RollupSpecMaltyped(field: String, expected: String, got: JValue)
-  extends SodaError("soda.rollup.maltyped",
+  extends SodaResponse("soda.rollup.maltyped",
     s"Rollup is maltyped; for field '$field' we expected '$expected' but got '$got'",
     "field" -> JString(field),
     "expected" -> JString(expected),
     "got" -> got)
 
 case class RollupCreationFailed(error: String)
-  extends SodaError("soda.rollup.creation-failed", s"Rollup column creation failed due to $error",
+  extends SodaResponse("soda.rollup.creation-failed", s"Rollup column creation failed due to $error",
     "error" -> JString(error))
 
 case class RollupColumnNotFound(value: ColumnName)
-  extends SodaError("soda.rollup.column-not-found", s"Rollup column '${value.name}' was not found",
+  extends SodaResponse("soda.rollup.column-not-found", s"Rollup column '${value.name}' was not found",
     "value" -> JString(value.name))
 
 case class RollupNotFound(value: RollupName)
-  extends SodaError("soda.rollup.not-found", s"Rollup '${value.name}' was not found",
+  extends SodaResponse("soda.rollup.not-found", s"Rollup '${value.name}' was not found",
     "value" -> JString(value.name))
 
 case class NonUniqueRowId(column: ColumnName)
-  extends SodaError("soda.column.not-unique",
+  extends SodaResponse("soda.column.not-unique",
     s"Row-Identifier column '${column.name}', which should contain unique values, instead contains duplicate values",
     "column" -> JString(column.name)
   )
 
 case class ColumnSpecUnknownType(typeName: TypeName)
-  extends SodaError("soda.column.unknown-type", s"Column is specified with unknown type ${typeName.name}",
+  extends SodaResponse("soda.column.unknown-type", s"Column is specified with unknown type ${typeName.name}",
     "type" -> JString(typeName.name))
 
 
 // NOT FOUND
 
 case class DatasetNotFound(value: ResourceName)
-  extends SodaError(SC_NOT_FOUND, "soda.dataset.not-found", s"Dataset '${value.name}' was not found",
+  extends SodaResponse(SC_NOT_FOUND, "soda.dataset.not-found", s"Dataset '${value.name}' was not found",
     "dataset" -> JString(value.name))
 
 case class ColumnNotFound(resourceName: ResourceName, columnName: ColumnName)
-  extends SodaError(SC_NOT_FOUND, "soda.dataset.column-not-found",
+  extends SodaResponse(SC_NOT_FOUND, "soda.dataset.column-not-found",
     s"Column ${columnName.name} was not found on dataset ${resourceName.name}",
     "dataset" -> JString(resourceName.name),
     "column"  -> JString(columnName.name))
 
 case class RowNotFound(value: RowSpecifier)
-  extends SodaError(SC_NOT_FOUND, "soda.row.not-found",
+  extends SodaResponse(SC_NOT_FOUND, "soda.row.not-found",
      s"Row with identifier ${value.underlying} was not found",
      "value" -> JString(value.underlying))
 
 case class SnapshotNotFound(value: ResourceName, snapshot: Long)
-  extends SodaError(SC_NOT_FOUND, "soda.snapshot.not-found", s"Snapshot ${snapshot} for dataset '${value.name}' was not found",
+  extends SodaResponse(SC_NOT_FOUND, "soda.snapshot.not-found", s"Snapshot ${snapshot} for dataset '${value.name}' was not found",
     "dataset" -> JString(value.name),
     "snapshot" -> JNumber(snapshot))
 
 // BAD REQUESTS
 
 case class BadParameter(param: String, value: String)
-  extends SodaError(SC_BAD_REQUEST, "req.bad-parameter",
+  extends SodaResponse(SC_BAD_REQUEST, "req.bad-parameter",
     s"Request has bad parameter '$param' with value '$value'",
     "parameter" -> JString(param),
     "value" -> JString(value))
 
 case class ColumnHasDependencies(columnName: ColumnName,
                                  deps: Seq[ColumnName])
-  extends SodaError(SC_BAD_REQUEST, "soda.column-with-dependencies-not-deleteable",
+  extends SodaResponse(SC_BAD_REQUEST, "soda.column-with-dependencies-not-deleteable",
      s"Cannot delete column ${columnName.name} because it has dependent columns $deps which must be deleted first",
      "column"       -> JString(columnName.name),
      "dependencies" -> JArray(deps.map { d => JString(d.name) }))
 
 case class DatasetAlreadyExistsSodaErr(dataset: ResourceName)
-  extends SodaError(SC_BAD_REQUEST, "soda.dataset.already-exists",
+  extends SodaResponse(SC_BAD_REQUEST, "soda.dataset.already-exists",
     s"Dataset ${dataset.name} already exists",
     "dataset" -> JString(dataset.name))
 
 case class DatasetNameInvalidNameSodaErr(dataset:  ResourceName)
-  extends SodaError(SC_BAD_REQUEST, "soda.dataset.invalid-Name",
+  extends SodaResponse(SC_BAD_REQUEST, "soda.dataset.invalid-Name",
     s"Dataset name '${dataset.name}' is invalid",
     "dataset" -> JString(dataset.name))
 /**
  * Column not found in a row operation
  */
 case class RowColumnNotFound(value: ColumnName)
-  extends SodaError(SC_BAD_REQUEST, "soda.row.column-not-found",
+  extends SodaResponse(SC_BAD_REQUEST, "soda.row.column-not-found",
     s"One or more rows expected column '${value.name}' which was not found on the dataset",
     "value" -> JString(value.name))
 
 case class ComputationHandlerNotFound(typ: StrategyType)
-  extends SodaError(SC_BAD_REQUEST, "soda.column.computation-handler-not-found",
+  extends SodaResponse(SC_BAD_REQUEST, "soda.column.computation-handler-not-found",
     s"Computation handler not found for computation strategy type ${typ.toString}",
     "computation-strategy" -> JString(typ.toString))
 
 case class NotAComputedColumn(value: ColumnName)
-  extends SodaError(SC_BAD_REQUEST, "soda.column.not-a-computed-column",
+  extends SodaResponse(SC_BAD_REQUEST, "soda.column.not-a-computed-column",
     s"Column ${value.name} is not a computed column",
     "value" -> JString(value.name))
 
 // internal intent is primary key; leaving the publicly-visible typing as "row-identifier"
 case object CannotDeletePrimaryKey
-  extends SodaError(SC_BAD_REQUEST, "soda.column.cannot-delete-row-identifier",
+  extends SodaResponse(SC_BAD_REQUEST, "soda.column.cannot-delete-row-identifier",
     s"Cannot delete the column which is currently defined as the row-identifier")
 
 // guessing as to the intended purpose of this one; there's nothing that uses this at the moment
 case object DeleteWithoutPrimaryKey
-  extends SodaError(SC_BAD_REQUEST, "soda.row.delete-without-primary-key",
+  extends SodaResponse(SC_BAD_REQUEST, "soda.row.delete-without-primary-key",
     s"Cannot delete an individual row without giving the primary key/row-identifier value")
 
 case class UpsertRowNotAnObject(obj: JValue)
-  extends SodaError(SC_BAD_REQUEST, "soda.row.upsert-row-not-an-object",
+  extends SodaResponse(SC_BAD_REQUEST, "soda.row.upsert-row-not-an-object",
     s"Row is not parseable as a json object: $obj",
     "value" -> obj)
 
 // value here seems pretty useless; haven't seen it set to anything useful, at least
 case class RowPrimaryKeyNonexistentOrNull(value: RowSpecifier)
-  extends SodaError(SC_BAD_REQUEST, "soda.row.primary-key-nonexistent-or-null",
+  extends SodaResponse(SC_BAD_REQUEST, "soda.row.primary-key-nonexistent-or-null",
     s"Row in dataset lacks a primary key or has the primary key column set to null",
     "value" -> JString(value.underlying))
 
 case class DatasetWriteLockError(dataset: ResourceName)
-  extends SodaError(SC_CONFLICT, "soda.dataset.cannot-acquire-write-lock",
+  extends SodaResponse(SC_CONFLICT, "soda.dataset.cannot-acquire-write-lock",
     s"Dataset ${dataset.name} cannot acquire a write lock",
     "dataset" -> JString(dataset.name))
 
 case class FeedbackInProgressError(dataset: ResourceName, stores: Set[String])
-  extends SodaError(SC_CONFLICT, "soda.dataset.feedback-in-progress",
+  extends SodaResponse(SC_CONFLICT, "soda.dataset.feedback-in-progress",
     s"Dataset ${dataset.name} is undergoing asynchronous processing; publication stage cannot be changed",
     "dataset" -> JString(dataset.name),
     "stores" -> JsonEncode.toJValue(stores))
 
 case class LocaleChangedError(locale: String)
-  extends SodaError(SC_CONFLICT, "soda.dataset.locale-changed",
+  extends SodaResponse(SC_CONFLICT, "soda.dataset.locale-changed",
     s"Dataset locale is different from the default locale of $locale",
     "locale" -> JString(locale))
 
 case class UnsupportedUpdateOperation(errMessage: String)
-  extends SodaError(SC_BAD_REQUEST, "soda.unsupported-update-operation",
+  extends SodaResponse(SC_BAD_REQUEST, "soda.unsupported-update-operation",
     s"Requested Update Operation is not supported.",
     "message" -> JString(errMessage))
 
 case object InvalidRowId
-  extends SodaError(SC_BAD_REQUEST, "soda.invalid-row-identifier",
+  extends SodaResponse(SC_BAD_REQUEST, "soda.invalid-row-identifier",
     s"Row-identifier is invalid")

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/wiremodels/ColumnSpec.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/wiremodels/ColumnSpec.scala
@@ -9,7 +9,7 @@ import com.socrata.soda.server.id.ColumnId
 import com.socrata.soda.server.util.AdditionalJsonCodecs._
 import com.socrata.soql.types.SoQLType
 import InputUtils._
-import com.socrata.soda.server.errors.{ColumnSpecMaltyped, ColumnSpecUnknownType}
+import com.socrata.soda.server.responses.{ColumnSpecMaltyped, ColumnSpecUnknownType}
 
 @JsonKeyStrategy(Strategy.Underscore)
 case class ColumnSpec(id: ColumnId,
@@ -51,7 +51,7 @@ object UserProvidedColumnSpec extends UserProvidedSpec[UserProvidedColumnSpec] {
   }
 
   // Using this class instead of AutomaticJsonCodecBuilder allows us to
-  // return a specific SodaError citing what part of the extraction failed.
+  // return a specific SodaResponse citing what part of the extraction failed.
   class ColumnExtractor(map: sc.Map[String, JValue]) {
     val context = new ExtractContext(ColumnSpecMaltyped)
     import context._

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/wiremodels/ComputationStrategySpec.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/wiremodels/ComputationStrategySpec.scala
@@ -4,7 +4,7 @@ import com.rojoma.json.v3.ast.{JString, JObject, JValue}
 import com.rojoma.json.v3.util.{AutomaticJsonCodecBuilder, Strategy, JsonKeyStrategy}
 import com.socrata.computation_strategies.StrategyType
 import com.socrata.soql.environment.ColumnName
-import com.socrata.soda.server.errors.{ComputationStrategySpecUnknownType, ComputationStrategySpecMaltyped}
+import com.socrata.soda.server.responses.{ComputationStrategySpecUnknownType, ComputationStrategySpecMaltyped}
 import com.socrata.soda.server.id.ColumnId
 import com.socrata.soda.server.wiremodels.InputUtils.ExtractContext
 import scala.{collection => sc}
@@ -59,7 +59,7 @@ object UserProvidedComputationStrategySpec extends UserProvidedSpec[UserProvided
   }
 
   // Using this class instead of AutomaticJsonCodecBuilder allows us to
-  // return a specific SodaError citing what part of the extraction failed.
+  // return a specific SodaResponse citing what part of the extraction failed.
   class ComputationStrategyExtractor(map: sc.Map[String, JValue]) {
     val context = new ExtractContext(ComputationStrategySpecMaltyped)
     import context._

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/wiremodels/DatasetSpec.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/wiremodels/DatasetSpec.scala
@@ -8,7 +8,7 @@ import com.rojoma.json.v3.codec.DecodeError.{InvalidField, InvalidType}
 import com.rojoma.json.v3.codec.JsonDecode.DecodeResult
 import com.rojoma.json.v3.util.{AutomaticJsonCodecBuilder, JsonKeyStrategy, Strategy}
 import com.socrata.soda.server.copy.Stage
-import com.socrata.soda.server.errors.DatasetSpecMaltyped
+import com.socrata.soda.server.responses.DatasetSpecMaltyped
 import com.socrata.soda.server.id.ResourceName
 import com.socrata.soda.server.wiremodels.InputUtils._
 import com.socrata.soda.server.util.AdditionalJsonCodecs._
@@ -74,7 +74,7 @@ object UserProvidedDatasetSpec extends UserProvidedSpec[UserProvidedDatasetSpec]
   }
 
   // Using this class instead of AutomaticJsonCodecBuilder allows us to
-  // return a specific SodaError citing what part of the extraction failed.
+  // return a specific SodaResponse citing what part of the extraction failed.
   private class DatasetExtractor(map: sc.Map[String, JValue]) {
     val context = new ExtractContext(DatasetSpecMaltyped)
     import context._

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/wiremodels/ExtractResult.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/wiremodels/ExtractResult.scala
@@ -1,6 +1,6 @@
 package com.socrata.soda.server.wiremodels
 
-import com.socrata.soda.server.errors.SodaError
+import com.socrata.soda.server.responses.SodaResponse
 import java.io.IOException
 
 sealed abstract class ExtractResult[+T] {
@@ -30,4 +30,4 @@ sealed abstract class ExtractFailure extends ExtractResult[Nothing] {
 }
 
 case class IOProblem(error: IOException) extends ExtractFailure
-case class RequestProblem(error: SodaError) extends ExtractFailure
+case class RequestProblem(error: SodaResponse) extends ExtractFailure

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/wiremodels/RollupSpec.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/wiremodels/RollupSpec.scala
@@ -2,7 +2,7 @@ package com.socrata.soda.server.wiremodels
 
 import com.rojoma.json.v3.ast.{JObject, JValue}
 import com.rojoma.json.v3.util.{AutomaticJsonCodecBuilder, Strategy, JsonKeyStrategy}
-import com.socrata.soda.server.errors.RollupSpecMaltyped
+import com.socrata.soda.server.responses.RollupSpecMaltyped
 
 import com.socrata.soda.server.id.RollupName
 import com.socrata.soda.server.wiremodels.InputUtils.ExtractContext
@@ -39,7 +39,7 @@ object UserProvidedRollupSpec extends UserProvidedSpec[UserProvidedRollupSpec] {
   }
 
   // Using this class instead of AutomaticJsonCodecBuilder allows us to
-  // return a specific SodaError citing what part of the extraction failed.
+  // return a specific SodaResponse citing what part of the extraction failed.
   class RollupExtractor(map: sc.Map[String, JValue]) {
     val context = new ExtractContext(RollupSpecMaltyped)
     import context._

--- a/soda-fountain-lib/src/test/scala/com/socrata/soda/server/services/ComputationStrategyExtractorTest.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/soda/server/services/ComputationStrategyExtractorTest.scala
@@ -5,7 +5,7 @@ import org.scalatest.{Matchers, FunSuite}
 import com.socrata.soda.server.wiremodels.{RequestProblem, Extracted, UserProvidedComputationStrategySpec}
 import com.rojoma.json.v3.util.JsonUtil
 import com.rojoma.json.v3.ast.{JString, JObject}
-import com.socrata.soda.server.errors.ComputationStrategySpecUnknownType
+import com.socrata.soda.server.responses.ComputationStrategySpecUnknownType
 
 class ComputationStrategyExtractorTest extends FunSuite with Matchers {
   def extract(input: String) = UserProvidedComputationStrategySpec.fromObject(JsonUtil.parseJson[JObject](input).right.get)


### PR DESCRIPTION
We keep logging things like "Error  responding with error not-modified:
Resource was not modified".  This offense my delicate sensibilities
as this isn't an error and we shouldn't say it is.  So rename the use of
"error" to be "response".

When reviewing, ensure nothing is actually changing in the HTTP
response.  All changes should be internal and only expressed in how
things are logged to avoid compatibility issues.