### PR TITLE
EN-5555: divide soda exception classes into internal errors and invalid

### DIFF
--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/SodaException.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/SodaException.scala
@@ -1,0 +1,7 @@
+package com.socrata.soda.server
+
+// exception subclass for errors which are caused by something internal
+class SodaInternalException(message: String, underlying: Throwable = null) extends Exception(message, underlying)
+
+// exception subclass for errors which are caused by e.g. bad input
+class SodaInvalidRequestException(message: String) extends Exception(message)

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/SodaFountain.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/SodaFountain.scala
@@ -62,7 +62,7 @@ class SodaFountain(config: SodaFountainConfig) extends Closeable {
           case e: Throwable if !e.isInstanceOf[Error] =>
             if (!resp.isCommitted) {
               resp.reset()
-              SodaUtils.internalError(req, e)(resp)
+              SodaUtils.handleError(req, e)(resp)
             } else {
               log.warn("Caught exception but the response is already committed; just cutting the client off" +
                 "\n" + e.getMessage, e)

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/computation/ComputationHandler.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/computation/ComputationHandler.scala
@@ -1,6 +1,7 @@
 package com.socrata.soda.server.computation
 
 import com.socrata.http.server.util.RequestId.RequestId
+import com.socrata.soda.server.{SodaInternalException, SodaInvalidRequestException}
 import com.socrata.soda.server.highlevel.RowDataTranslator
 import com.socrata.soda.server.persistence._
 import com.socrata.soql.environment.ColumnName
@@ -35,8 +36,7 @@ trait ComputationHandler extends java.io.Closeable {
 }
 
 object ComputationHandler {
-  // TODO: These are repeated from RowDAOImpl.  Let's share these somehow.  Or maybe we just make them private.
-  case class UnknownColumnEx(colName: ColumnName) extends Exception
-  case class MaltypedDataEx(col: ColumnName, expected: SoQLType, got: SoQLType) extends Exception
-  case class ComputationEx(message: String, underlying: Option[Throwable]) extends Exception(message, underlying.orNull)
+  case class UnknownColumnEx(colName: ColumnName) extends SodaInvalidRequestException(s"Unknown column $colName")
+  case class MaltypedDataEx(col: ColumnName, expected: SoQLType, got: SoQLType) extends SodaInvalidRequestException(s"Invalid data for column $col; expected a $expected and got a $got")
+  case class ComputationEx(message: String, underlying: Option[Throwable]) extends SodaInternalException(message, underlying.orNull)
 }

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/export/GeoJsonExporter.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/export/GeoJsonExporter.scala
@@ -5,6 +5,7 @@ import com.rojoma.json.v3.io.{CompactJsonWriter, JsonReader}
 import com.rojoma.simplearm.util._
 import com.socrata.http.common.util.AliasedCharset
 import com.socrata.http.server.HttpResponse
+import com.socrata.soda.server.SodaInternalException
 import com.socrata.soda.server.highlevel.ExportDAO
 import com.socrata.soda.server.highlevel.ExportDAO.ColumnInfo
 import com.socrata.soda.server.persistence.ColumnRecordLike
@@ -127,5 +128,5 @@ class GeoJsonProcessor(writer: BufferedWriter, schema: ExportDAO.CSchema, single
  * Helpful objects related to GeoJSON processing
  */
 object GeoJsonProcessor {
-  object InvalidGeoJsonSchema extends Exception
+  object InvalidGeoJsonSchema extends SodaInternalException("Invalid geojson schema")
 }

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/CJson.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/CJson.scala
@@ -3,6 +3,7 @@ package com.socrata.soda.server.highlevel
 import com.rojoma.json.v3.ast.{JArray, JValue}
 import com.rojoma.json.v3.codec.JsonDecode
 import com.rojoma.json.v3.util.{JsonKey, Strategy, JsonKeyStrategy, AutomaticJsonCodecBuilder}
+import com.socrata.soda.server.SodaInternalException
 import com.socrata.soda.server.id.ColumnId
 import com.socrata.soda.server.wiremodels.{JsonColumnReadRep, JsonColumnRep}
 import com.socrata.soql.environment.ColumnName
@@ -59,7 +60,7 @@ object CJson {
   // either success or failure casses.
 
   // EXCEPTIONS
-  class CJsonException(msg: String) extends Exception(msg)
+  class CJsonException(msg: String) extends SodaInternalException(msg)
 
   case object NoSchemaPresent extends CJsonException("No Schema Present")
   case class CannotDecodeSchema(value: JValue) extends CJsonException(s"Could not decode Schema: $value")

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/RowDAO.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/RowDAO.scala
@@ -89,6 +89,7 @@ object RowDAO {
   case class DatasetNotFound(dataset: ResourceName) extends UpsertFailResult
   case class UnknownColumn(column: ColumnName) extends UpsertFailResult
   case object CannotDeletePrimaryKey extends UpsertFailResult
+  case object DeleteWithoutPrimaryKey extends UpsertFailResult
   case class InvalidRequest(client: String, status: Int, body: JValue) extends UpsertFailResult
   case class RowNotAnObject(value: JValue) extends UpsertFailResult
   case class InternalServerError(status: Int = 500, client: String = "QC", code: String, tag: String, data: String) extends UpsertFailResult

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/RowDataTranslator.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/RowDataTranslator.scala
@@ -7,6 +7,7 @@ import com.socrata.http.server.util.RequestId.RequestId
 import com.socrata.soda.clients.datacoordinator.{DeleteRow, UpsertRow, RowUpdate}
 import com.socrata.soda.server.computation.ComputedColumnsLike
 import com.socrata.soda.server.id.ColumnId
+import com.socrata.soda.server.{SodaInvalidRequestException, SodaInternalException}
 import com.socrata.soda.server.persistence.{DatasetRecordLike, ColumnRecordLike}
 import com.socrata.soda.server.wiremodels.{JsonColumnRep, JsonColumnWriteRep, JsonColumnReadRep}
 import com.socrata.soql.environment.ColumnName
@@ -160,9 +161,9 @@ object RowDataTranslator {
   case class UpsertAsSoQL(rowData: Map[String, SoQLValue]) extends Computable
   case class DeleteAsCJson(pk: JValue) extends Computable
 
-  case class MaltypedDataEx(col: ColumnName, expected: SoQLType, got: JValue) extends Exception(s"Expected $expected type for column $col, but got value $got")
-  case class UnknownColumnEx(col: ColumnName) extends Exception(s"Unrecognized column $col")
-  case object DeleteNoPKEx extends Exception
-  case class NotAnObjectOrSingleElementArrayEx(obj: JValue) extends Exception(s"Inappropriate JValue $obj")
-  case class ComputationHandlerNotFoundEx(typ: StrategyType) extends Exception(s"Computation strategy $typ was not found")
+  case class MaltypedDataEx(col: ColumnName, expected: SoQLType, got: JValue) extends SodaInvalidRequestException(s"Expected $expected type for column $col, but got value $got")
+  case class UnknownColumnEx(col: ColumnName) extends SodaInvalidRequestException(s"Unrecognized column $col")
+  case object DeleteNoPKEx extends SodaInvalidRequestException(s"Cannot delete row without giving primary key")
+  case class NotAnObjectOrSingleElementArrayEx(obj: JValue) extends SodaInvalidRequestException(s"Inappropriate JValue $obj")
+  case class ComputationHandlerNotFoundEx(typ: StrategyType) extends SodaInternalException(s"Computation strategy $typ was not found")
 }

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/persistence/pg/PostgresStoreImpl.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/persistence/pg/PostgresStoreImpl.scala
@@ -3,6 +3,7 @@ package com.socrata.soda.server.persistence.pg
 import java.sql.{Connection, ResultSet, Timestamp, Types}
 
 import com.socrata.computation_strategies.StrategyType
+import com.socrata.soda.server.SodaInternalException
 import com.socrata.soda.server.persistence.NameAndSchemaStore.ColumnUpdater
 
 import scala.annotation.tailrec
@@ -22,7 +23,7 @@ import com.socrata.soql.types.SoQLType
 import javax.sql.DataSource
 import org.joda.time.DateTime
 
-case class SodaFountainStoreError(message: String) extends Exception(message)
+case class SodaFountainStoreError(message: String) extends SodaInternalException(message)
 
 class PostgresStoreImpl(dataSource: DataSource) extends NameAndSchemaStore {
 

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/UpsertUtils.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/UpsertUtils.scala
@@ -31,7 +31,7 @@ object UpsertUtils {
       case UnknownColumnEx(columnName)               =>
         handleResponse(RowDAO.UnknownColumn(columnName))
       case DeleteNoPKEx                              =>
-        handleResponse(RowDAO.CannotDeletePrimaryKey)
+        handleResponse(RowDAO.DeleteWithoutPrimaryKey)
       case NotAnObjectOrSingleElementArrayEx(obj)    =>
         handleResponse(RowDAO.RowNotAnObject(obj))
       case ComputationHandlerNotFoundEx(typ)         =>
@@ -57,6 +57,8 @@ object UpsertUtils {
         SodaUtils.response(request, SodaErrors.ComputationHandlerNotFound(typ))(response)
       case RowDAO.CannotDeletePrimaryKey =>
         SodaUtils.response(request, SodaErrors.CannotDeletePrimaryKey)(response)
+      case RowDAO.DeleteWithoutPrimaryKey =>
+        SodaUtils.response(request, SodaErrors.DeleteWithoutPrimaryKey)(response)
       case RowDAO.RowNotAnObject(obj) =>
         SodaUtils.response(request, SodaErrors.UpsertRowNotAnObject(obj))(response)
       case RowDAO.DatasetNotFound(dataset) =>

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/responses/responses.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/responses/responses.scala
@@ -40,6 +40,16 @@ case class InternalException(th: Throwable, tag: String)
   override def excludedFields = Set("errorMessage", "errorClass", "stackTrace")
 }
 
+case class SodaInvalidRequest(th: Throwable, tag: String)
+  extends SodaResponse(SC_BAD_REQUEST, "invalid-request",
+    s"Invalid request: ${Option(th.getMessage).getOrElse("")}",
+    "errorMessage" -> JString(Option(th.getMessage).getOrElse("")),
+    "errorClass"   -> JString(th.getClass.getCanonicalName),
+    "stackTrace"   -> JArray(th.getStackTrace.map(x => JString(x.toString)))
+  ) {
+  override def excludedFields = Set("errorMessage", "errorClass", "stackTrace")
+}
+
 case class HttpMethodNotAllowed(method: String, allowed: TraversableOnce[String])
   extends SodaResponse(SC_METHOD_NOT_ALLOWED, "method-not-allowed",
     s"HTTP method $method is not allowed for this request",


### PR DESCRIPTION
requests

Then at the top level, handle these appropriately with 4xx and 5xx
responses and logging.
Also fix one spot where we were erroneously throwing
CannotDeletePrimaryKey instead of DeleteWithoutPrimaryKey.