### PR TITLE
EN-6888: Bump version of computation strategy lib

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
     val balboa            = "0.14.0"
     val c3po              = "0.9.2.1"
     val codahaleMetrics   = "3.0.2"
-    val computationStrategies = "0.0.2"
+    val computationStrategies = "0.0.4"
     val dropWizardMetrics = "3.1.0"
     val javaxServletApi   = "2.5"
     val liquibaseCore     = "2.0.0"

--- a/soda-fountain-lib/src/test/scala/com/socrata/soda/server/highlevel/ColumnSpecUtilsTest.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/soda/server/highlevel/ColumnSpecUtilsTest.scala
@@ -168,7 +168,7 @@ class ColumnSpecUtilsTest extends FunSuite with Matchers {
         sourceColumns = Some(Seq("my_column")),
         parameters = None
       )))
-    testFreeze(existingColumns, ucs, InvalidComputationStrategy(MissingParameters(StrategyType.Test)))
+    testFreeze(existingColumns, ucs, InvalidComputationStrategy(MissingParameters(TestParameterSchema)))
   }
 
   test("freezeForCreation - test computed column strategy type \"geocoding\"") {


### PR DESCRIPTION
New version of library implements validation for
`georegion_match_on_point` and `georegion_match_on_string`
computation strategies.