### PR TITLE
Switch to turn off region-coding in soda-fountain

### DIFF
--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/SodaFountain.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/SodaFountain.scala
@@ -12,7 +12,7 @@ import com.socrata.http.server.util.RequestId.ReqIdHeader
 import com.socrata.soda.clients.datacoordinator.{CuratedHttpDataCoordinatorClient, DataCoordinatorClient}
 import com.socrata.soda.clients.regioncoder.CuratedRegionCoderClient
 import com.socrata.soda.clients.querycoordinator.{CuratedHttpQueryCoordinatorClient, QueryCoordinatorClient}
-import com.socrata.soda.server.computation.ComputedColumns
+import com.socrata.soda.server.computation.{ComputingGate, ComputedColumns}
 import com.socrata.soda.server.config.SodaFountainConfig
 import com.socrata.soda.server.highlevel._
 import com.socrata.soda.server.persistence.pg.PostgresStoreImpl
@@ -155,7 +155,9 @@ class SodaFountain(config: SodaFountainConfig) extends Closeable {
 
   val store: NameAndSchemaStore = i(new PostgresStoreImpl(dataSource))
 
-  val computedColumns = new ComputedColumns(config.handlers, discovery)
+  val computingGate = si(new ComputingGate(curator, "/soda-fountain"))
+
+  val computedColumns = new ComputedColumns(config.handlers, discovery, computingGate)
 
   val datasetDAO = i(new DatasetDAOImpl(dc, store, columnSpecUtils, () => config.dataCoordinatorClient.instance))
   val columnDAO = i(new ColumnDAOImpl(dc, store, columnSpecUtils))

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/computation/ComputedColumns.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/computation/ComputedColumns.scala
@@ -10,7 +10,7 @@ import org.apache.curator.x.discovery.ServiceDiscovery
  * @param handlersConfig a Typesafe Config containing an entry for configuring each handler.
  * @param discovery the ServiceDiscovery instance used for discovering other services using ZK/Curator
  */
-class ComputedColumns[T](handlersConfig: Config, discovery: ServiceDiscovery[T]) extends ComputedColumnsLike {
+class ComputedColumns[T](handlersConfig: Config, discovery: ServiceDiscovery[T], computingGate: () => Boolean) extends ComputedColumnsLike {
 
   /**
    * Instantiates a computation handler handle a given computation strategy type.
@@ -28,4 +28,6 @@ class ComputedColumns[T](handlersConfig: Config, discovery: ServiceDiscovery[T])
     handlersConfig.getConfig("region-coder"), discovery)
   private def geoRegionMatchOnStringHandler = new GeoregionMatchOnStringHandler(
     handlersConfig.getConfig("region-coder"), discovery)
+
+  def computingEnabled = computingGate()
 }

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/computation/ComputedColumnsLike.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/computation/ComputedColumnsLike.scala
@@ -30,6 +30,11 @@ trait ComputedColumnsLike {
     datasetRecord.columns.filter { col => col.computationStrategy.isDefined }
 
   /**
+   * Dynamically gate the actual running of computation strategies
+   */
+  def computingEnabled: Boolean
+
+  /**
    * Performs the (hopefully lazy) computation of all computed columns, producing a new iterator with
    * the new computed columns filled in.   The computations are chained, one computed column at a time;
    * thus if all computation handlers are lazy then the processing can happen incrementally.
@@ -48,7 +53,7 @@ trait ComputedColumnsLike {
     for (computedColumn <- computedColumns) {
       val strategyType = computedColumn.computationStrategy.get.strategyType
       // only add computed columns that have synchronous computation strategies
-      if (StrategyType.computeSynchronously(strategyType)) {
+      if (StrategyType.computeSynchronously(strategyType) && computingEnabled) {
         val tryGetHandler = handlers.get(strategyType)
         tryGetHandler match {
           case Some(handlerCreator) =>

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/computation/ComputingGate.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/computation/ComputingGate.scala
@@ -1,0 +1,26 @@
+package com.socrata.soda.server.computation
+
+import java.io.Closeable
+import java.nio.charset.StandardCharsets
+
+import org.apache.curator.framework.CuratorFramework
+import org.apache.curator.framework.recipes.cache.NodeCache
+
+class ComputingGate(curator: CuratorFramework, path: String) extends (() => Boolean) with Closeable {
+  val nc = new NodeCache(curator, path + "/computation-enabled")
+
+  def start(): Unit = {
+    nc.start(true)
+  }
+
+  def close(): Unit = {
+    nc.close()
+  }
+
+  def apply(): Boolean = {
+    val d = nc.getCurrentData
+    d == null || !java.util.Arrays.equals(d.getData, falseBytes)
+  }
+
+  val falseBytes = "false".getBytes(StandardCharsets.UTF_8)
+}

--- a/soda-fountain-lib/src/test/scala/com/socrata/soda/server/TestComputedColumns.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/soda/server/TestComputedColumns.scala
@@ -7,4 +7,5 @@ object TestComputedColumns extends ComputedColumnsLike {
   val handlers = Map[StrategyType, () => ComputationHandler](
     StrategyType.Test      -> (() => new TestComputationHandler)
   )
+  def computingEnabled = true
 }


### PR DESCRIPTION
Controlled via zookeeper; defaults to "region-coding is enabled".