### PR TITLE
EN-6887: Add region/geocoded datasets to secondary manifest

### DIFF
--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/datacoordinator/FeedbackSecondaryManifestClient.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/datacoordinator/FeedbackSecondaryManifestClient.scala
@@ -1,0 +1,26 @@
+package com.socrata.soda.clients.datacoordinator
+
+import com.socrata.computation_strategies.StrategyType
+import com.socrata.soda.server.id.{DatasetId, SecondaryId}
+
+class FeedbackSecondaryManifestClient(dc: DataCoordinatorClient,
+                                      feedbackSecondaryIdMap: Map[StrategyType, SecondaryId]) {
+  val log = org.slf4j.LoggerFactory.getLogger(classOf[FeedbackSecondaryManifestClient])
+
+  def maybeReplicate(datasetId: DatasetId,
+                     strategyTypes: Set[StrategyType],
+                     extraHeaders: Map[String, String]): Unit = {
+    strategyTypes.flatMap { typ => feedbackSecondaryIdMap.get(typ) }.foreach { secondaryId =>
+      try {
+        dc.propagateToSecondary(datasetId, secondaryId, extraHeaders)
+        log.info(s"Added dataset ${datasetId.toString} to secondary manifest for feedback secondary {}",
+          secondaryId.toString)
+      } catch {
+        case error: Exception =>
+          // TODO: DataCoordinatorClient.propagateToSecondary(.) really should have better error handling...
+          log.error("Failed to add dataset {} to secondary manifest for feedback secondary {}: {}",
+            datasetId.toString, secondaryId.toString, error)
+      }
+    }
+  }
+}

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/config/SodaFountainConfig.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/config/SodaFountainConfig.scala
@@ -24,6 +24,7 @@ class SodaFountainConfig(config: Config) extends ConfigClass(WithDefaultAddress(
   val threadpool = getRawConfig("threadpool")
   val tableDropDelay = getDuration("tableDropDelay")
   val dataCleanupInterval = getInt("dataCleanupInterval")
+  val computationStrategySecondaryId = optionally(getRawConfig("computation-strategy-secondary-id"))
 }
 
 class DataCoordinatorClientConfig(config: Config, root: String) extends ConfigClass(config, root) {

--- a/soda-fountain-lib/src/test/scala/com/socrata/soda/server/highlevel/ColumnDAOSpec.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/soda/server/highlevel/ColumnDAOSpec.scala
@@ -1,6 +1,6 @@
 package com.socrata.soda.server.highlevel
 
-import com.socrata.soda.clients.datacoordinator.DataCoordinatorClient
+import com.socrata.soda.clients.datacoordinator.{FeedbackSecondaryManifestClient, DataCoordinatorClient}
 import com.socrata.soda.server.DatasetsForTesting
 import com.socrata.soda.server.copy.Latest
 import com.socrata.soda.server.highlevel.ColumnDAO._
@@ -19,12 +19,13 @@ class ColumnDAOSpec extends FunSuiteLike
     val toDelete = ColumnName("blah")
 
     val dc = mock[DataCoordinatorClient]
+    val fbm = new FeedbackSecondaryManifestClient(dc, Map.empty)
     val ns = mock[NameAndSchemaStore]
     ns.expects('lookupDataset)(dataset.resourceName, Some(Latest))
       .returning(Some(dataset)).anyNumberOfTimes()
     val col = new ColumnSpecUtils(Random)
 
-    val dao: ColumnDAO = new ColumnDAOImpl(dc, ns, col)
+    val dao: ColumnDAO = new ColumnDAOImpl(dc, fbm, ns, col)
 
     val result = dao.deleteColumn("user", dataset.resourceName, toDelete, "1234")
 
@@ -38,12 +39,13 @@ class ColumnDAOSpec extends FunSuiteLike
     val requestId = "1234"
 
     val dc = mock[DataCoordinatorClient]
+    val fbm = new FeedbackSecondaryManifestClient(dc, Map.empty)
     val ns = mock[NameAndSchemaStore]
     ns.expects('lookupDataset)(dataset.resourceName, Some(Latest))
       .returning(Some(dataset)).anyNumberOfTimes()
     val col = new ColumnSpecUtils(Random)
 
-    val dao: ColumnDAO = new ColumnDAOImpl(dc, ns, col)
+    val dao: ColumnDAO = new ColumnDAOImpl(dc, fbm, ns, col)
 
     val result = dao.deleteColumn("user", dataset.resourceName, toDelete.fieldName, requestId)
 
@@ -56,13 +58,14 @@ class ColumnDAOSpec extends FunSuiteLike
     val requestId = "1234"
 
     val dc = mock[DataCoordinatorClient]
+    val fbm = new FeedbackSecondaryManifestClient(dc, Map.empty)
     val ns = mock[NameAndSchemaStore]
     ns.expects('lookupDataset)(dataset.resourceName, Some(Latest))
       .returning(Some(dataset)).anyNumberOfTimes()
     dc.expects('update)(*, *, *, *, *, *)
     val col = new ColumnSpecUtils(Random)
 
-    val dao: ColumnDAO = new ColumnDAOImpl(dc, ns, col)
+    val dao: ColumnDAO = new ColumnDAOImpl(dc, fbm, ns, col)
 
     dao.deleteColumn("user", dataset.resourceName, toDelete.fieldName, requestId)
 

--- a/soda-fountain-lib/src/test/scala/com/socrata/soda/server/highlevel/DatasetDAOSpec.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/soda/server/highlevel/DatasetDAOSpec.scala
@@ -1,6 +1,6 @@
 package com.socrata.soda.server.highlevel
 
-import com.socrata.soda.clients.datacoordinator.DataCoordinatorClient
+import com.socrata.soda.clients.datacoordinator.{FeedbackSecondaryManifestClient, DataCoordinatorClient}
 import com.socrata.soda.server.copy.{Published, Unpublished}
 import com.socrata.soda.server.id.ResourceName
 import com.socrata.soda.server.persistence.NameAndSchemaStore
@@ -16,13 +16,14 @@ class DatasetDAOSpec extends FunSuiteLike with Matchers with MockFactory with Pr
     val expectedCopyNum = Some(42)
 
     val dc = mock[DataCoordinatorClient]
+    val fbm = new FeedbackSecondaryManifestClient(dc, Map.empty)
     val ns = mock[NameAndSchemaStore]
     ns.expects('lookupCopyNumber)(dataset, None).returning(Some(1)).anyNumberOfTimes()
     ns.expects('lookupCopyNumber)(dataset, Some(Published)).returning(expectedCopyNum)
     val col = new ColumnSpecUtils(Random)
     val instance = () => "test"
 
-    val dao: DatasetDAO = new DatasetDAOImpl(dc, ns, col, instance)
+    val dao: DatasetDAO = new DatasetDAOImpl(dc, fbm, ns, col, instance)
 
     val copynum = dao.getCurrentCopyNum(dataset)
 
@@ -34,13 +35,14 @@ class DatasetDAOSpec extends FunSuiteLike with Matchers with MockFactory with Pr
     val expectedCopyNum = Some(42)
 
     val dc = mock[DataCoordinatorClient]
+    val fbm = new FeedbackSecondaryManifestClient(dc, Map.empty)
     val ns = mock[NameAndSchemaStore]
     ns.expects('lookupCopyNumber)(dataset, Some(Published)).returning(None)
     ns.expects('lookupCopyNumber)(dataset, Some(Unpublished)).returning(expectedCopyNum)
     val col = new ColumnSpecUtils(Random)
     val instance = () => "test"
 
-    val dao: DatasetDAO = new DatasetDAOImpl(dc, ns, col, instance)
+    val dao: DatasetDAO = new DatasetDAOImpl(dc, fbm, ns, col, instance)
 
     val copynum = dao.getCurrentCopyNum(dataset)
 


### PR DESCRIPTION
Support the ability to add datasets with computed columns to
the secondary manifest for the appropriate feedback secondary.
 * Map from `computation_strategy` to (feedback) `secondary_id`
   is configurable.