### PR TITLE
EN-5578:  Expand `/dataset-version/_4x4` endpoint

### DIFF
--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/datacoordinator/DataCoordinatorClient.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/datacoordinator/DataCoordinatorClient.scala
@@ -15,7 +15,13 @@ object DataCoordinatorClient {
   val client = "DC"
 
   @JsonKeyStrategy(Strategy.Underscore)
-  case class SecondaryVersionsReport(truthVersion: Long, secondaries: Map[String, Long], feedbackSecondaries: Set[String])
+  case class SecondaryVersionsReport(truthVersion: Option[Long], // TODO: remove this once `latestVersion` is not optional and CRJ is no-longer looking for it
+                                     latestVersion: Option[Long], // TODO: make this not an Option once data-coordinator is always sending it
+                                     publishedVersion: Option[Long],
+                                     unpublishedVersion: Option[Long],
+                                     secondaries: Map[String, Long],
+                                     feedbackSecondaries: Set[String],
+                                     groups: Option[Map[String, Set[String]]]) // TODO: make this not an Option once data-coordinator is always sending it
   object SecondaryVersionsReport {
     implicit val codec = AutomaticJsonCodecBuilder[SecondaryVersionsReport]
   }


### PR DESCRIPTION
Changes to `/dataset-version/_4x4` endpoint:
 * `truth_version` is now optional
 * adds `latest` data-version
 * adds `published` data-version
 * adds `unpublished` data-version
 * adds `groups` - a map from `group_name` to the set of
   `store_id`s (only the `store_id`s that the
    dataset is replicated to)

All new fields are optional.