### PR TITLE
EN-123901: Don't deadlock when region coding fails

### DIFF
--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/Compute.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/Compute.scala
@@ -17,7 +17,7 @@ case class Compute(columnDAO: ColumnDAO,
 
   case class service(resourceName: ResourceName, columnName: ColumnName) extends SodaResource {
     override def post = { req => resp =>
-      computeUtils.compute(req, resp, resourceName, columnName, user(req)) {
+      computeUtils.compute(req, resp, req.resourceScope, resourceName, columnName, user(req)) {
         computeUtils.writeComputeResponse(
           resourceName, columnName, HttpServletResponse.SC_OK, _: HttpServletResponse, _: Iterator[ReportItem])
       }

--- a/soda-fountain-lib/src/test/scala/com/socrata/soda/server/resources/ComputeTest.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/soda/server/resources/ComputeTest.scala
@@ -1,5 +1,6 @@
 package com.socrata.soda.server.resources
 
+import com.rojoma.simplearm.v2.ResourceScope
 import com.socrata.http.server.HttpRequest
 import com.socrata.http.server.HttpRequest.AugmentedHttpServletRequest
 import com.socrata.soda.server.{TestComputedColumns, DatasetsForTesting}
@@ -57,6 +58,7 @@ class ComputeTest extends FunSuite with Matchers with MockFactory with DatasetsF
 
     val httpReq = mock[HttpRequest]
     val augReq = new AugmentedHttpServletRequest(request)
+    httpReq.expects('resourceScope)().returning(new ResourceScope())
     httpReq.expects('servletRequest)().anyNumberOfTimes.returning(augReq)
 
     val getColumnResponse = dataset match {


### PR DESCRIPTION
When computing a newly created computed column, if
computation fails, then close the export from
data-coordinator before trying to drop the column
from truth.