### PR TITLE
Exclude JMS from dependencies

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -15,7 +15,14 @@ object BuildSettings {
         styleCheck in Compile := {},
         scalaVersion := "2.10.4",
 
-        resolvers += "velvia maven" at "http://dl.bintray.com/velvia/maven"
+        resolvers += "velvia maven" at "http://dl.bintray.com/velvia/maven",
+
+        ivyXML :=
+          <dependencies>
+            <exclude org="com.sun.jmx" module="jmxri"/>         <!--   / log4j          -->
+            <exclude org="com.sun.jdmk" module="jmxtools"/>     <!--  <  extra          -->
+            <exclude org="javax.jms" module="jms"/>             <!--   \ deps           -->
+          </dependencies>
       )
 
   def projectSettings(assembly: Boolean = false): Seq[Setting[_]] =


### PR DESCRIPTION
Not sure why this is only showing up now, but it did happen.

Giacomo saw it on his machine... no clue why, but these files are
legit not in Maven.  We're already excluding them elsewhere.