### PR TITLE
EN-15144: Pass resource_name to data-coordinator

### DIFF
--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/datacoordinator/DataCoordinatorClient.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/datacoordinator/DataCoordinatorClient.scala
@@ -110,7 +110,8 @@ trait DataCoordinatorClient {
                            extraHeaders: Map[String, String] = Map.empty)
   def getSchema(datasetId: DatasetId): Option[SchemaSpec]
 
-  def create(instance: String,
+  def create(resource: ResourceName,
+             instance: String,
              user: String,
              instructions: Option[Iterator[DataCoordinatorInstruction]],
              locale: String = "en_US",

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/datacoordinator/DatasetCopyInstruction.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/datacoordinator/DatasetCopyInstruction.scala
@@ -1,8 +1,10 @@
 package com.socrata.soda.clients.datacoordinator
 
+import com.socrata.soda.server.id.ResourceName
+
 sealed abstract class DatasetCopyInstruction { val command: String}
 
-case class CreateDataset(locale: String = "en_US") extends DatasetCopyInstruction { val command = "create"}
+case class CreateDataset(resource: ResourceName, locale: String = "en_US") extends DatasetCopyInstruction { val command = "create"}
 case class CopyDataset(copyData: Boolean, schema: String) extends DatasetCopyInstruction { val command = "copy"}
 case class PublishDataset(keepSnapshot: Option[Boolean], schema: String) extends DatasetCopyInstruction { val command = "publish"}
 case class DropDataset(schema: String) extends DatasetCopyInstruction { val command = "drop"}

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/datacoordinator/HttpDataCoordinatorClient.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/datacoordinator/HttpDataCoordinatorClient.scala
@@ -9,7 +9,7 @@ import com.socrata.http.common.util.HttpUtils
 import com.socrata.http.server.implicits._
 import com.socrata.http.server.routing.HttpMethods
 import com.socrata.http.server.util._
-import com.socrata.soda.server.id.{ColumnId, RowSpecifier, DatasetId, SecondaryId}
+import com.socrata.soda.server.id._
 import com.socrata.soda.server.util.schema.SchemaSpec
 import javax.servlet.http.HttpServletResponse
 import org.joda.time.DateTime
@@ -300,13 +300,14 @@ abstract class HttpDataCoordinatorClient(httpClient: HttpClient) extends DataCoo
       case Left(e) => f(e)
     }
 
-  def create(instance: String,
+  def create(resource: ResourceName,
+             instance: String,
              user: String,
              instructions: Option[Iterator[DataCoordinatorInstruction]],
              locale: String = "en_US",
              extraHeaders: Map[String, String] = Map.empty): (ReportMetaData, Iterable[ReportItem]) = {
     withHost(instance) { host =>
-      val createScript = new MutationScript(user, CreateDataset(locale), instructions.getOrElse(Array().iterator))
+      val createScript = new MutationScript(user, CreateDataset(resource, locale), instructions.getOrElse(Array().iterator))
       sendScript(createUrl(host).addHeaders(extraHeaders), createScript) {
         case Right(r) =>
           val events = r.jsonEvents().buffered

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/datacoordinator/MutationScript.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/datacoordinator/MutationScript.scala
@@ -134,7 +134,7 @@ class MutationScript(
 
   def topLevelCommand: Map[String, JValue] = {
     copyInstruction match {
-      case i: CreateDataset => Map("locale" -> JString(i.locale), "c" -> JString(copyInstruction.command), "user" -> JString(user))
+      case i: CreateDataset => Map("resource" -> JString(i.resource.name), "locale" -> JString(i.locale), "c" -> JString(copyInstruction.command), "user" -> JString(user))
       case i: UpdateDataset => topLevelCommandBase(i.schema)
       case i: CopyDataset   => topLevelCommandBase(i.schema) + ("copy_data" -> JBoolean(i.copyData))
       case i: PublishDataset=> i.keepSnapshot match {

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/DatasetDAOImpl.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/DatasetDAOImpl.scala
@@ -94,7 +94,8 @@ class DatasetDAOImpl(dc: DataCoordinatorClient,
 
         val instructions = columnInstructions ++ addRidInstruction
 
-        val (reportMetaData, _) = dc.create(instanceForCreate(),
+        val (reportMetaData, _) = dc.create(spec.resourceName,
+                                            instanceForCreate(),
                                             user,
                                             Some(instructions.iterator),
                                             spec.locale,


### PR DESCRIPTION
Pass on dataset `resource_name` in mutation script
to data-coordinator upon dataset creation. This is
so secondary-watcher can send replication complete
events with dataset external ids for waiting for
computing column statistics.