### PR TITLE
EN-16161 - Add Zookeeper Whitelist for Secondary Geo- and Region-Coding

### DIFF
--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/computation/ComputedColumns.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/computation/ComputedColumns.scala
@@ -1,7 +1,10 @@
 package com.socrata.soda.server.computation
 
 import com.socrata.computation_strategies.StrategyType
+import com.socrata.soda.server.id.ResourceName
+
 import com.typesafe.config.Config
+
 import org.apache.curator.x.discovery.ServiceDiscovery
 
 /**
@@ -10,7 +13,7 @@ import org.apache.curator.x.discovery.ServiceDiscovery
  * @param handlersConfig a Typesafe Config containing an entry for configuring each handler.
  * @param discovery the ServiceDiscovery instance used for discovering other services using ZK/Curator
  */
-class ComputedColumns[T](handlersConfig: Config, discovery: ServiceDiscovery[T], computingGate: () => Boolean) extends ComputedColumnsLike {
+class ComputedColumns[T](handlersConfig: Config, discovery: ServiceDiscovery[T], computingGate: ResourceName => Boolean) extends ComputedColumnsLike {
 
   /**
    * Instantiates a computation handler handle a given computation strategy type.
@@ -29,5 +32,5 @@ class ComputedColumns[T](handlersConfig: Config, discovery: ServiceDiscovery[T],
   private def geoRegionMatchOnStringHandler = new GeoregionMatchOnStringHandler(
     handlersConfig.getConfig("region-coder"), discovery)
 
-  def computingEnabled = computingGate()
+  def computingEnabled(resourceName: ResourceName): Boolean = computingGate(resourceName)
 }

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/computation/ComputingGate.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/computation/ComputingGate.scala
@@ -1,26 +1,72 @@
 package com.socrata.soda.server.computation
 
+import com.socrata.soda.server.id.ResourceName
+
 import java.io.Closeable
 import java.nio.charset.StandardCharsets
 
 import org.apache.curator.framework.CuratorFramework
 import org.apache.curator.framework.recipes.cache.NodeCache
 
-class ComputingGate(curator: CuratorFramework, path: String) extends (() => Boolean) with Closeable {
-  val nc = new NodeCache(curator, path + "/computation-enabled")
+
+class ComputingGate(curator: CuratorFramework, path: String) extends (ResourceName => Boolean) with Closeable {
+  val log: org.slf4j.Logger = org.slf4j.LoggerFactory.getLogger(classOf[ComputingGate])
+  val sfComputingEnabledForEnvironmentNodeCache = new NodeCache(curator, path + "/computation-enabled")
+  val sfComputingEnabledForResourceNameNodeCache = new NodeCache(curator, path + "/computation-blacklist")
 
   def start(): Unit = {
-    nc.start(true)
+    sfComputingEnabledForEnvironmentNodeCache.start(true)
+    sfComputingEnabledForResourceNameNodeCache.start(true)
   }
 
   def close(): Unit = {
-    nc.close()
+    sfComputingEnabledForEnvironmentNodeCache.close()
+    sfComputingEnabledForResourceNameNodeCache.close()
   }
 
-  def apply(): Boolean = {
-    val d = nc.getCurrentData
-    d == null || !java.util.Arrays.equals(d.getData, falseBytes)
-  }
+  // In the comments below we speak in terms of Soda Fountain's computation being _enabled_. This is because we want
+  // to eventually disable it by changing (a) value(s) in Zookeeper, rather than simply enable the Secondary to do the
+  // work instead--in other words, whether or not the Secondary will perform the computation is unrelated to whether
+  // or not Soda Fountain will, and as such we want to wean Soda Fountain off of the computation racket by first
+  // blacklisting some resources by ResourceName and eventually telling Soda Fountain it should never perform the
+  // computation (by adding the string value "false" to the "/com.socrata/soda/soda-fountain/computation-enabled" path
+  // in Zookeeper).
+  def apply(resourceName: ResourceName): Boolean = {
+    val falseAsBytes = "false".getBytes(StandardCharsets.UTF_8)
 
-  val falseBytes = "false".getBytes(StandardCharsets.UTF_8)
+    // We want Soda Fountain to do the computation if...
+    val sfComputingEnabledForEnvironment = Option(sfComputingEnabledForEnvironmentNodeCache.getCurrentData) match {
+      // ...the "/com.socrata/soda/soda-fountain/computation-enabled" path exists and the data associated with the
+      // node is not equal to the string "false"
+      case Some(enabledForEnvironment) => !java.util.Arrays.equals(enabledForEnvironment.getData, falseAsBytes)
+      // ...or if the "/com.socrata/soda/soda-fountain/computation-enabled" node does not exist at all.
+      case None => true
+    }
+
+    // We want Soda Fountain to do the computation if the resourceName associated with the operation is not in the
+    // resource name blacklist.
+    val sfComputingEnabledForResourceName = Option(sfComputingEnabledForResourceNameNodeCache.getCurrentData) match {
+      case Some(resourceNameBlacklist) => !new String(resourceNameBlacklist.getData, StandardCharsets.UTF_8).
+        split(',').
+        toSeq.
+        map(new ResourceName(_)).
+        contains(resourceName)
+      case None => true
+    }
+
+    val logMessage = (sfComputingEnabledForEnvironment, sfComputingEnabledForResourceName) match {
+      case (true, true) => "Performing computation in Soda Fountain; computation enabled for environment and " +
+        s"""resource name "${resourceName.toString}" is not in the computation blacklist."""
+      case (true, false) => "Not performing computation in Soda Fountain; computation enabled for environment but " +
+        s"""resource name "${resourceName.toString}" is in the computation blacklist."""
+      case (false, true) => "Not performing computation in Soda Fountain; computation not enabled for environment " +
+        s"""but resource name "${resourceName.toString}" is not in the computation blacklist."""
+      case (false, false) => "Not performing computation in Soda Fountain; computation not enabled for environment " +
+        s"""and resource name "${resourceName.toString}" is in the computation blacklist."""
+    }
+    log.info(logMessage)
+
+    // We only actually want Soda Fountain to do the computation if both of the above conditions are met.
+    sfComputingEnabledForEnvironment && sfComputingEnabledForResourceName
+  }
 }

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/RowDataTranslator.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/RowDataTranslator.scala
@@ -87,7 +87,7 @@ class RowDataTranslator(requestId: RequestId,
                                      rows: Iterator[Computable]): Iterator[RowUpdate] = {
     import ComputedColumnsLike._
 
-    val computedResult = cc.addComputedColumns(requestId, rows, toCompute)
+    val computedResult = cc.addComputedColumns(requestId, dataset.resourceName, rows, toCompute)
     computedResult match {
       case ComputeSuccess(computedRows) =>
         val rowUpdates = computedRows.map {

--- a/soda-fountain-lib/src/test/scala/com/socrata/soda/server/TestComputedColumns.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/soda/server/TestComputedColumns.scala
@@ -1,11 +1,12 @@
 package com.socrata.soda.server
 
 import com.socrata.computation_strategies.StrategyType
-import com.socrata.soda.server.computation.{TestComputationHandler, ComputationHandler, ComputedColumnsLike}
+import com.socrata.soda.server.computation.{ComputationHandler, ComputedColumnsLike, TestComputationHandler}
+import com.socrata.soda.server.id.ResourceName
 
 object TestComputedColumns extends ComputedColumnsLike {
   val handlers = Map[StrategyType, () => ComputationHandler](
     StrategyType.Test      -> (() => new TestComputationHandler)
   )
-  def computingEnabled = true
+  def computingEnabled(resourceName: ResourceName) = true
 }


### PR DESCRIPTION
- Refactor ComputingGate to accept a resource name and then check if it exists in a whitelist (stored in Zookeeper) before deciding whether or not to send the geo- or region-coding job to the secondary as opposed to doing it in Soda Fountain itself.
- We are doing this so that we can selectively test the correctness and stability of the new geo- and region-coding secondary on a dataset-by-dataset basis before turning it on globally per environment.
- We expect the entire ComputingGate mechanism to be removed at the same time that we disable Soda Fountain's geo- and region-coding functionality.