### PR TITLE
EN-16106: Increase table drop delay to 15 days.

### DIFF
--- a/soda-fountain-lib/src/main/resources/reference.conf
+++ b/soda-fountain-lib/src/main/resources/reference.conf
@@ -2,7 +2,7 @@ com.socrata.soda-fountain = {
   max-datum-size = 70000000
   upsert-ignore-extra-columns = false
   etag-obfuscation-key = null
-  tableDropDelay = 14 days
+  tableDropDelay = 15 days
   dataCleanupInterval = 30
 
   service-advertisement {


### PR DESCRIPTION
We want a general policy of 2 weeks so we will configure soda fountain to have
an extra day just so we don't run into a case where code upstream hasn't dropped it
yet but soda fountain has.