### PR TITLE
EN-17534: Don't do work when computation is off

### DIFF
--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/computation/ComputedColumnsLike.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/computation/ComputedColumnsLike.scala
@@ -55,7 +55,7 @@ trait ComputedColumnsLike {
     for (computedColumn <- computedColumns) {
       val strategyType = computedColumn.computationStrategy.get.strategyType
       // only add computed columns that have synchronous computation strategies
-      if (StrategyType.computeSynchronously(strategyType) && computingEnabled(resourceName)) {
+      if (StrategyType.computeSynchronously(strategyType)) {
         val tryGetHandler = handlers.get(strategyType)
         tryGetHandler match {
           case Some(handlerCreator) =>

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/ComputeUtils.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/ComputeUtils.scala
@@ -71,7 +71,7 @@ class ComputeUtils(columnDAO: ColumnDAO, exportDAO: ExportDAO, rowDAO: RowDAO, c
               user: String)
              (successHandler: (HttpServletResponse, Iterator[ReportItem]) => Unit): Unit =
     column.computationStrategy match {
-      case Some(strategy) =>
+      case Some(strategy) if computedColumns.computingEnabled(dataset.resourceName) =>
         val columns = columnsToExport(RequestId.getFromRequest(req), dataset, strategy)
         val requestId = RequestId.getFromRequest(req)
         log.info("export dataset {} for column compute", dataset.resourceName.name)
@@ -104,6 +104,8 @@ class ComputeUtils(columnDAO: ColumnDAO, exportDAO: ExportDAO, rowDAO: RowDAO, c
               "data" -> JString(data)
             ))(response)
         }
+      case Some(_) =>
+        log.info("skipping computation for dataset {} for column compute", dataset.resourceName.name)
       case None =>
         SodaUtils.response(req, SodaError.NotAComputedColumn(column.fieldName))(response)
     }


### PR DESCRIPTION
Don't do extra work when computation has been
disabled for a given dataset. The uneeded upserting
of the source column done by soda-fountain is
causing geocoding secondary to get 409s while
it is trying to region code large datasets.