### PR TITLE
EN-17537: Don't check for deleted tables to drop insanely frequently.

### DIFF
--- a/soda-fountain-lib/src/main/resources/com/socrata/soda/server/persistence/pg/20170712-add-datasets-deleted-at-index.xml
+++ b/soda-fountain-lib/src/main/resources/com/socrata/soda/server/persistence/pg/20170712-add-datasets-deleted-at-index.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <changeSet author="marcs" id="1" runInTransaction="false">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                select count(*) from pg_class where relname = 'datasets_deleted_at'
+            </sqlCheck>
+        </preConditions>
+        <sql>
+            CREATE INDEX CONCURRENTLY datasets_deleted_at on datasets(deleted_at)
+        </sql>
+        <rollback>
+            <dropIndex indexName="datasets_deleted_at" tableName="datasets"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/soda-fountain-lib/src/main/resources/com/socrata/soda/server/persistence/pg/migrate.xml
+++ b/soda-fountain-lib/src/main/resources/com/socrata/soda/server/persistence/pg/migrate.xml
@@ -14,4 +14,5 @@
     <include file="com/socrata/soda/server/persistence/pg/21050724-add-deleted-at-column-multi-tables.xml"/>
     <include file="com/socrata/soda/server/persistence/pg/20160308-add-recompute-default-value.xml"/>
     <include file="com/socrata/soda/server/persistence/pg/20160309-drop-recompute-from-computation-strategies.xml"/>
+    <include file="com/socrata/soda/server/persistence/pg/20170712-add-datasets-deleted-at-index.xml"/>
 </databaseChangeLog>

--- a/soda-fountain-lib/src/main/resources/reference.conf
+++ b/soda-fountain-lib/src/main/resources/reference.conf
@@ -3,7 +3,7 @@ com.socrata.soda-fountain = {
   upsert-ignore-extra-columns = false
   etag-obfuscation-key = null
   tableDropDelay = 15 days
-  dataCleanupInterval = 30
+  dataCleanupInterval = 1 hour
 
   service-advertisement {
     service-base-path = "/services"

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/config/SodaFountainConfig.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/config/SodaFountainConfig.scala
@@ -24,7 +24,7 @@ class SodaFountainConfig(config: Config) extends ConfigClass(WithDefaultAddress(
   val codaMetrics = getRawConfig("metrics")
   val threadpool = getRawConfig("threadpool")
   val tableDropDelay = getDuration("tableDropDelay")
-  val dataCleanupInterval = getInt("dataCleanupInterval")
+  val dataCleanupInterval = getDuration("dataCleanupInterval")
   val computationStrategySecondaryId = optionally(getRawConfig("computation-strategy-secondary-id"))
 }
 

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/persistence/pg/Migration.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/persistence/pg/Migration.scala
@@ -3,6 +3,7 @@ package com.socrata.soda.server.persistence.pg
 import java.sql.Connection
 
 import liquibase.Liquibase
+import liquibase.lockservice.LockService
 import liquibase.resource.ClassLoaderResourceAccessor
 
 object Migration {
@@ -17,6 +18,9 @@ object Migration {
   {
     val jdbc = new NonCommmittingJdbcConnenction(conn)
     val liquibase = new Liquibase(changeLogPath, new ClassLoaderResourceAccessor(), jdbc)
+    val lockService = LockService.getInstance(liquibase.getDatabase)
+    lockService.setChangeLogLockWaitTime(1000 * 3) // 3s where value should be < SQL lock_timeout (30s)
+
     val database = conn.getCatalog
 
     operation match {


### PR DESCRIPTION
And add index on datasets(deleted_at).  Looking up datasets to delete was the 
second most expensive query hitting soda-fountain by CPU.