### PR TITLE
EN-17534: Fix bug in 73dfa0c6ecdfd5e1930b369e5a9dcdb9c04322a8

### DIFF
--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/ComputeUtils.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/ComputeUtils.scala
@@ -106,6 +106,7 @@ class ComputeUtils(columnDAO: ColumnDAO, exportDAO: ExportDAO, rowDAO: RowDAO, c
         }
       case Some(_) =>
         log.info("skipping computation for dataset {} for column compute", dataset.resourceName.name)
+        successHandler(response, Iterator.empty)
       case None =>
         SodaUtils.response(req, SodaError.NotAComputedColumn(column.fieldName))(response)
     }


### PR DESCRIPTION
Call the success handler when skipping computation when computation
is not enabled for a dataset. So soda-fountain can return the correct
response when a computed column is created. Also note this means
when the /compute endpoint is used and the computing gate is off
it will say it computed 0 rows (which is true).