### PR TITLE
A very basic backup plan to collocate dataset on soda2 query.

### DIFF
--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/SodaFountain.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/SodaFountain.scala
@@ -199,7 +199,7 @@ class SodaFountain(config: SodaFountainConfig) extends Closeable {
     val dataset = Dataset(datasetDAO, config.maxDatumSize)
     val column = DatasetColumn(columnDAO, exportDAO, rowDAO, computedColumns, etagObfuscator, config.maxDatumSize)
     val export = Export(exportDAO, etagObfuscator)
-    val resource = Resource(rowDAO, datasetDAO, etagObfuscator, config.maxDatumSize, computedColumns, metricProvider, export)
+    val resource = Resource(rowDAO, datasetDAO, etagObfuscator, config.maxDatumSize, computedColumns, metricProvider, export, dc)
     val compute = Compute(columnDAO, exportDAO, rowDAO, computedColumns, etagObfuscator)
     val suggest = Suggest(datasetDAO, columnDAO, httpClient, config.suggest)
     val snapshots = Snapshots(snapshotDAO)

--- a/soda-fountain-lib/src/test/scala/com/socrata/datacoordinator/client/HttpDatatCoordinatorClientTest.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/datacoordinator/client/HttpDatatCoordinatorClientTest.scala
@@ -15,10 +15,9 @@ import org.scalatest.{FunSuite, Matchers, Tag}
 
 class HttpDatatCoordinatorClientTest extends FunSuite with Matchers {
 
-
   object tag extends Tag("HttpDatatCoordinatorClientTest")
 
-  val client = new MyClient
+  val client = new HttpDatatCoordinatorClientTest.MyClient
 
   // Helper to write errors
   case class ReqError(errorCode: String, data: Map[String, JValue])
@@ -96,6 +95,9 @@ class HttpDatatCoordinatorClientTest extends FunSuite with Matchers {
     def headers(name: String): Array[String] = Seq("application/json").toArray
     def headerNames = Set.empty
   }
+}
+
+object HttpDatatCoordinatorClientTest {
 
   class MyClient extends HttpDataCoordinatorClient(null){
     def hostO(instance: String): Option[RequestBuilder] = None

--- a/soda-fountain-lib/src/test/scala/com/socrata/soda/server/metrics/QueryMetricTest.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/soda/server/metrics/QueryMetricTest.scala
@@ -2,19 +2,20 @@ package com.socrata.soda.server.metrics
 
 import com.rojoma.json.v3.ast.JString
 import com.rojoma.simplearm.v2.ResourceScope
+import com.socrata.datacoordinator.client.HttpDatatCoordinatorClientTest
 import com.socrata.http.server.HttpRequest.AugmentedHttpServletRequest
 import com.socrata.http.server.routing.OptionallyTypedPathComponent
 import com.socrata.http.server.util.Precondition
-import com.socrata.soda.clients.datacoordinator.RowUpdate
+import com.socrata.soda.clients.datacoordinator.{DataCoordinatorClient, RowUpdate}
 import com.socrata.soda.server._
 import com.socrata.soda.server.copy.Stage
-import com.socrata.soda.server.highlevel.{ExportDAO, DatasetDAO, RowDAO}
+import com.socrata.soda.server.highlevel.{DatasetDAO, ExportDAO, RowDAO}
 import com.socrata.soda.server.highlevel.ExportDAO.CSchema
 import com.socrata.soda.server.highlevel.RowDAO.{Result, UpsertResult}
 import com.socrata.soda.server.id.{ResourceName, RowSpecifier}
 import com.socrata.soda.server.metrics.Metrics._
 import com.socrata.soda.server.metrics.TestDatasets._
-import com.socrata.soda.server.persistence.{DatasetRecord, ColumnRecordLike, ColumnRecord, DatasetRecordLike}
+import com.socrata.soda.server.persistence.{ColumnRecord, ColumnRecordLike, DatasetRecord, DatasetRecordLike}
 import com.socrata.soda.server.resources.{Export, Resource}
 import com.socrata.soda.server.util.{ETagObfuscator, NoopEtagObfuscator}
 import com.socrata.soql.types.SoQLValue
@@ -119,7 +120,7 @@ class SingleRowQueryMetricTest extends QueryMetricTestBase {
   def mockDatasetQuery(dataset: TestDataset, provider: MetricProvider, headers: Map[String, String]) {
     val export = new Export(mock[ExportDAO], ETagObfuscator.noop)
     val mockResource = new Resource(new QueryOnlyRowDAO(TestDatasets.datasets), mock[DatasetDAO],
-                                    NoopEtagObfuscator, 1000, null, provider, export)
+                                    NoopEtagObfuscator, 1000, null, provider, export, new HttpDatatCoordinatorClientTest.MyClient())
     val mockServReq = new MockHttpServletRequest()
     mockServReq.setRequestURI(s"http://sodafountain/resource/${dataset.dataset}/some-row-id.json")
     headers.foreach(header => mockServReq.addHeader(header._1, header._2))
@@ -188,7 +189,7 @@ class MultiRowQueryMetricTest extends QueryMetricTestBase {
     headers.foreach(header => mockServReq.addHeader(header._1, header._2))
     val httpReq = httpRequest(augReq)
     val mockResource = new Resource(new QueryOnlyRowDAO(TestDatasets.datasets), mock[DatasetDAO],
-                                    NoopEtagObfuscator, 1000, null, provider, export)
+                                    NoopEtagObfuscator, 1000, null, provider, export, new HttpDatatCoordinatorClientTest.MyClient())
 
     mockResource.service(OptionallyTypedPathComponent(dataset.resource, None)).get(httpReq)(new MockHttpServletResponse())
   }


### PR DESCRIPTION
This is at least useful for development

curl -H ‘X-Socrata-Collocate: true’ ‘http://sf:6010/resource/4x4?$query=select * join @x on @x.c=c’