### PR TITLE
A very basic backup plan to collocate dataset on soda2 query.

### DIFF
--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/SodaFountain.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/SodaFountain.scala
@@ -199,7 +199,7 @@ class SodaFountain(config: SodaFountainConfig) extends Closeable {
     val dataset = Dataset(datasetDAO, config.maxDatumSize)
     val column = DatasetColumn(columnDAO, exportDAO, rowDAO, computedColumns, etagObfuscator, config.maxDatumSize)
     val export = Export(exportDAO, etagObfuscator)
-    val resource = Resource(rowDAO, datasetDAO, etagObfuscator, config.maxDatumSize, computedColumns, metricProvider, export)
+    val resource = Resource(rowDAO, datasetDAO, etagObfuscator, config.maxDatumSize, computedColumns, metricProvider, export, dc)
     val compute = Compute(columnDAO, exportDAO, rowDAO, computedColumns, etagObfuscator)
     val suggest = Suggest(datasetDAO, columnDAO, httpClient, config.suggest)
     val snapshots = Snapshots(snapshotDAO)

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/Resource.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/Resource.scala
@@ -7,8 +7,7 @@ import com.socrata.soda.clients.datacoordinator.DataCoordinatorClient.ReportItem
 
 import scala.collection.JavaConverters._
 import scala.language.existentials
-
-import com.rojoma.json.v3.ast.{JNumber, JString, JValue}
+import com.rojoma.json.v3.ast.{JArray, JNumber, JString, JValue}
 import com.rojoma.simplearm.util._
 import com.rojoma.simplearm.v2.ResourceScope
 import com.socrata.http.common.util.ContentNegotiation
@@ -17,14 +16,14 @@ import com.socrata.http.server.implicits._
 import com.socrata.http.server.responses._
 import com.socrata.http.server.routing.OptionallyTypedPathComponent
 import com.socrata.http.server.util.{EntityTag, Precondition, RequestId}
-import com.socrata.soda.clients.datacoordinator.RowUpdate
-import com.socrata.soda.clients.querycoordinator.QueryCoordinatorClient
+import com.socrata.soda.clients.datacoordinator.{DataCoordinatorClient, RowUpdate}
+import com.socrata.soda.clients.querycoordinator.{QueryCoordinatorClient, QueryCoordinatorError}
 import com.socrata.soda.server.{responses => SodaErrors, _}
 import com.socrata.soda.server.computation.ComputedColumnsLike
 import com.socrata.soda.server.copy.Stage
 import com.socrata.soda.server.export.Exporter
 import com.socrata.soda.server.highlevel.{DatasetDAO, RowDAO, RowDataTranslator}
-import com.socrata.soda.server.id.{ResourceName, RowSpecifier}
+import com.socrata.soda.server.id.{DatasetId, ResourceName, RowSpecifier, SecondaryId}
 import com.socrata.soda.server.metrics.{MetricProvider, NoopMetricProvider}
 import com.socrata.soda.server.metrics.Metrics.{QuerySuccess => QuerySuccessMetric, _}
 import com.socrata.soda.server.persistence.{ColumnRecordLike, DatasetRecordLike}
@@ -42,7 +41,8 @@ case class Resource(rowDAO: RowDAO,
                     maxRowSize: Long,
                     cc: ComputedColumnsLike,
                     metricProvider: MetricProvider,
-                    export: Export) extends Metrics {
+                    export: Export,
+                    dc: DataCoordinatorClient) extends Metrics {
   import Resource._
 
   val log = org.slf4j.LoggerFactory.getLogger(classOf[Resource])
@@ -233,6 +233,9 @@ case class Resource(rowDAO: RowDAO,
                     SodaUtils.response(req, SodaErrors.RequestTimedOut(timeout))
                   case RowDAO.QCError(status, qcErr) =>
                     metricByStatus(status)
+                    if (Option(req.getHeader("X-Socrata-Collocate")) == Some("true")) {
+                      collocateDataset(qcErr)
+                    }
                     SodaUtils.response(req, SodaErrors.ErrorReportedByQueryCoordinator(status, qcErr))
                   case RowDAO.InvalidRequest(client, status, body) =>
                     metricByStatus(status)
@@ -288,6 +291,26 @@ case class Resource(rowDAO: RowDAO,
           upsertishFlow(req, response, requestId, resourceName.value, boundedIt, f, processUpsertReport)
         case Left(err) =>
           SodaUtils.response(req, err, resourceName.value)(response)
+      }
+    }
+
+    private def collocateDataset(qcErr: QueryCoordinatorError): Unit = {
+      qcErr match {
+        case QueryCoordinatorError("query.dataset.is-not-collocated", Some(description), data) =>
+          (data("resource"), data("secondaries")) match {
+            case (JString(resource), JArray(Seq(JString(sec), _*))) =>
+              val resourceName = new ResourceName(resource)
+              datasetDAO.getDataset(resourceName, None) match {
+                case DatasetDAO.Found(datasetRecord) =>
+                  val dsId = datasetRecord.systemId
+                  val secId = SecondaryId(sec.split("\\.").head)
+                  log.info("collocate {} dataset {} in {}", resourceName, dsId.underlying, secId)
+                  dc.propagateToSecondary(dsId, secId, Map.empty)
+                case _ =>
+              }
+            case _ =>
+          }
+        case _ =>
       }
     }
   }

--- a/soda-fountain-lib/src/test/scala/com/socrata/datacoordinator/client/HttpDatatCoordinatorClientTest.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/datacoordinator/client/HttpDatatCoordinatorClientTest.scala
@@ -15,10 +15,9 @@ import org.scalatest.{FunSuite, Matchers, Tag}
 
 class HttpDatatCoordinatorClientTest extends FunSuite with Matchers {
 
-
   object tag extends Tag("HttpDatatCoordinatorClientTest")
 
-  val client = new MyClient
+  val client = new HttpDatatCoordinatorClientTest.MyClient
 
   // Helper to write errors
   case class ReqError(errorCode: String, data: Map[String, JValue])
@@ -96,6 +95,9 @@ class HttpDatatCoordinatorClientTest extends FunSuite with Matchers {
     def headers(name: String): Array[String] = Seq("application/json").toArray
     def headerNames = Set.empty
   }
+}
+
+object HttpDatatCoordinatorClientTest {
 
   class MyClient extends HttpDataCoordinatorClient(null){
     def hostO(instance: String): Option[RequestBuilder] = None

--- a/soda-fountain-lib/src/test/scala/com/socrata/soda/server/metrics/QueryMetricTest.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/soda/server/metrics/QueryMetricTest.scala
@@ -2,19 +2,20 @@ package com.socrata.soda.server.metrics
 
 import com.rojoma.json.v3.ast.JString
 import com.rojoma.simplearm.v2.ResourceScope
+import com.socrata.datacoordinator.client.HttpDatatCoordinatorClientTest
 import com.socrata.http.server.HttpRequest.AugmentedHttpServletRequest
 import com.socrata.http.server.routing.OptionallyTypedPathComponent
 import com.socrata.http.server.util.Precondition
-import com.socrata.soda.clients.datacoordinator.RowUpdate
+import com.socrata.soda.clients.datacoordinator.{DataCoordinatorClient, RowUpdate}
 import com.socrata.soda.server._
 import com.socrata.soda.server.copy.Stage
-import com.socrata.soda.server.highlevel.{ExportDAO, DatasetDAO, RowDAO}
+import com.socrata.soda.server.highlevel.{DatasetDAO, ExportDAO, RowDAO}
 import com.socrata.soda.server.highlevel.ExportDAO.CSchema
 import com.socrata.soda.server.highlevel.RowDAO.{Result, UpsertResult}
 import com.socrata.soda.server.id.{ResourceName, RowSpecifier}
 import com.socrata.soda.server.metrics.Metrics._
 import com.socrata.soda.server.metrics.TestDatasets._
-import com.socrata.soda.server.persistence.{DatasetRecord, ColumnRecordLike, ColumnRecord, DatasetRecordLike}
+import com.socrata.soda.server.persistence.{ColumnRecord, ColumnRecordLike, DatasetRecord, DatasetRecordLike}
 import com.socrata.soda.server.resources.{Export, Resource}
 import com.socrata.soda.server.util.{ETagObfuscator, NoopEtagObfuscator}
 import com.socrata.soql.types.SoQLValue
@@ -119,7 +120,7 @@ class SingleRowQueryMetricTest extends QueryMetricTestBase {
   def mockDatasetQuery(dataset: TestDataset, provider: MetricProvider, headers: Map[String, String]) {
     val export = new Export(mock[ExportDAO], ETagObfuscator.noop)
     val mockResource = new Resource(new QueryOnlyRowDAO(TestDatasets.datasets), mock[DatasetDAO],
-                                    NoopEtagObfuscator, 1000, null, provider, export)
+                                    NoopEtagObfuscator, 1000, null, provider, export, new HttpDatatCoordinatorClientTest.MyClient())
     val mockServReq = new MockHttpServletRequest()
     mockServReq.setRequestURI(s"http://sodafountain/resource/${dataset.dataset}/some-row-id.json")
     headers.foreach(header => mockServReq.addHeader(header._1, header._2))
@@ -188,7 +189,7 @@ class MultiRowQueryMetricTest extends QueryMetricTestBase {
     headers.foreach(header => mockServReq.addHeader(header._1, header._2))
     val httpReq = httpRequest(augReq)
     val mockResource = new Resource(new QueryOnlyRowDAO(TestDatasets.datasets), mock[DatasetDAO],
-                                    NoopEtagObfuscator, 1000, null, provider, export)
+                                    NoopEtagObfuscator, 1000, null, provider, export, new HttpDatatCoordinatorClientTest.MyClient())
 
     mockResource.service(OptionallyTypedPathComponent(dataset.resource, None)).get(httpReq)(new MockHttpServletResponse())
   }


### PR DESCRIPTION
This is at least useful for development

curl -H ‘X-Socrata-Collocate: true’ ‘http://sf:6010/resource/4x4?$query=select * join @x on @x.c=c’