### PR TITLE
EN-7442: Allow empty sources on geocomputed column

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
     val balboa            = "0.14.0"
     val c3p0              = "0.9.5.2"
     val codahaleMetrics   = "3.0.2"
-    val computationStrategies = "0.0.4"
+    val computationStrategies = "0.1.0"
     val dropWizardMetrics = "3.1.0"
     val javaxServletApi   = "2.5"
     val liquibaseCore     = "2.0.0"


### PR DESCRIPTION
Work around how coreserver serializes JSON (i.e. removing fields
containing empty objects). No creating geocoding computed columns
with no sources succeeds with status 200.