### PR TITLE
EN-19155: bump soqlReference version to 2.9.1 to support CollectionExtract fns

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,7 +24,7 @@ object Dependencies {
     val scalaj            = "0.3.15"
     val socrataHttp       = "3.11.2"
     val soqlBrita         = "1.3.0"
-    val soqlReference     = "2.9.0"
+    val soqlReference     = "2.9.1"
     val thirdPartyUtils   = "4.0.5"
     val curatorUtils      = "1.0.3"
     val typesafeConfig    = "1.0.2"


### PR DESCRIPTION
To support changes here: https://github.com/socrata-platform/soql-reference/pull/92