### PR TITLE
SPARTA: Stop using soda2.conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 keystore.jks
 /*.log
 target/
+configs/local-soda-fountain.conf

--- a/bin/run_migrations.sh
+++ b/bin/run_migrations.sh
@@ -6,7 +6,7 @@ set -e
 REALPATH=$(python -c "import os; print(os.path.realpath('$0'))")
 BINDIR=$(dirname "$REALPATH")
 
-CONFIG="${SODA_CONFIG:-/etc/soda2.conf}" # TODO: Don't depend on soda2.conf.
+CONFIG="configs/application.conf"
 JARFILE=$("$BINDIR"/build.sh "$@")
 
 COMMAND=${1:-migrate}

--- a/bin/start_soda_fountain.sh
+++ b/bin/start_soda_fountain.sh
@@ -5,7 +5,7 @@ set -e
 REALPATH=$(python -c "import os; print(os.path.realpath('$0'))")
 BINDIR=$(dirname "$REALPATH")
 
-CONFIG="${SODA_CONFIG:-/etc/soda2.conf}" # TODO: Don't depend on soda2.conf.
+CONFIG="configs/application.conf"
 JARFILE=$("$BINDIR"/build.sh "$@")
 
 "$BINDIR"/run_migrations.sh

--- a/configs/application.conf
+++ b/configs/application.conf
@@ -1,0 +1,6 @@
+# Sensible defaults for a development environment
+include "sample-soda-fountain.conf"
+
+# This file is .gitignored; you can create it and make
+# any changes you like there.
+include "local-soda-fountain.conf"

--- a/configs/sample-soda-fountain.conf
+++ b/configs/sample-soda-fountain.conf
@@ -1,0 +1,32 @@
+com.socrata.soda-fountain  {
+  database {
+    host = "localhost"
+    port = 5432
+    database = "sodafountain"
+    username = "blist"
+    password = "blist"
+  }
+
+  data-coordinator-client {
+    instances-for-new-datasets = ["primus"]
+  }
+
+  network.port = 6010
+
+  curator.ensemble = ["localhost:2181"]
+
+  suggest {
+    host = "localhost"
+    port = 8042
+  }
+
+  computation-strategy-secondary-id {
+    geocoding = "geocoding"
+    georegion_match_on_point = "geocoding"
+    georegion = "geocoding"
+    georegion_match_on_string = "geocoding"
+  }
+
+  log4j.appender.console.props.ayout.props.ConversionPattern =
+    "[%t] (%X{job-id}) (%X{X-Socrata-RequestId}) [%X{dataset-id}] %p %c{1} %d %m%n"
+}


### PR DESCRIPTION
Remove references to `soda2.conf` and replace them with checked in
configs. A gitignored file `configs/local-soda-fountain.conf` can
be used to customize the configuration for local development.