### PR TITLE
EN-22044: Explicit use of local.dev.socrata.net

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 keystore.jks
 /*.log
 target/
-configs/local-soda-fountain.conf
+configs/local*.conf

--- a/configs/application.conf
+++ b/configs/application.conf
@@ -1,6 +1,6 @@
 # Sensible defaults for a development environment
-include "sample-soda-fountain.conf"
+include "sample.conf"
 
 # This file is .gitignored; you can create it and make
 # any changes you like there.
-include "local-soda-fountain.conf"
+include "local.conf"

--- a/configs/sample.conf
+++ b/configs/sample.conf
@@ -1,6 +1,10 @@
+# use local.dev.socrata.net to support solo which resolves to 127.0.0.1
+common-host = "local.dev.socrata.net"
+common-zk-ensemble = ["local.dev.socrata.net:2181"]
+
 com.socrata.soda-fountain  {
   database {
-    host = "localhost"
+    host = ${common-host}
     port = 5432
     database = "sodafountain"
     username = "blist"
@@ -13,10 +17,10 @@ com.socrata.soda-fountain  {
 
   network.port = 6010
 
-  curator.ensemble = ["localhost:2181"]
+  curator.ensemble = ${common-zk-ensemble}
 
   suggest {
-    host = "localhost"
+    host = ${common-host}
     port = 8042
   }
 


### PR DESCRIPTION
Clearly comment that it was for solo (becaus I was confused).
Also, a little bit of config renaming to match spandex based
off of code reviews there.