### PR TITLE
EN-17026: Pass data-coordinator collocation limits

### DIFF
--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/datacoordinator/DataCoordinatorClient.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/datacoordinator/DataCoordinatorClient.scala
@@ -7,7 +7,7 @@ import com.socrata.soda.server.id._
 import com.socrata.soda.server.persistence.ColumnRecord
 import com.socrata.soda.server.util.CopySpecifier
 import com.socrata.soda.server.util.schema.SchemaSpec
-import com.socrata.http.server.util.{Precondition, EntityTag}
+import com.socrata.http.server.util.{EntityTag, Precondition}
 import com.socrata.soda.server.resources.DCCollocateOperation
 import org.joda.time.DateTime
 
@@ -38,13 +38,18 @@ object DataCoordinatorClient {
   case class UpsertReportItem(data: Iterator[JValue] /* Note: this MUST be completely consumed before calling hasNext/next on parent iterator! */) extends ReportItem
   case object OtherReportItem extends ReportItem
 
-  case class Cost(moves: Int)
+  @JsonKeyStrategy(Strategy.Underscore)
+  case class Cost(moves: Int, totalSizeBytes: Long, moveSizeMaxBytes: Option[Long] = None)
   object Cost {
     implicit val codec = AutomaticJsonCodecBuilder[Cost]
   }
 
   @JsonKeyStrategy(Strategy.Underscore)
-  case class Move(datasetInternalName: String, storeIdFrom: String, storeIdTo: String)
+  case class Move(datasetInternalName: String,
+                  storeIdFrom: String,
+                  storeIdTo: String,
+                  cost: Cost,
+                  complete: Option[Boolean] = None)
   object Move {
     implicit val codec = AutomaticJsonCodecBuilder[Move]
   }

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/DatasetDAOImpl.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/DatasetDAOImpl.scala
@@ -517,7 +517,7 @@ class DatasetDAOImpl(dc: DataCoordinatorClient,
 
   def collocate(secondaryId: SecondaryId, operation: SFCollocateOperation, explain: Boolean, jobId: String): Result = {
     def translate(resource: ResourceName): Option[DatasetId] = store.translateResourceName(resource).map(_.systemId)
-    DCCollocateOperation(operation, translate) match {
+    DCCollocateOperation(operation, translate _) match {
       case Left(op) =>
         // TODO: Translate dc errors better, need to clarify what actually needs to be propogated
         dc.collocate(secondaryId, op, explain, jobId) match {

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/CollocateOperation.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/CollocateOperation.scala
@@ -3,12 +3,13 @@ package com.socrata.soda.server.resources
 import com.rojoma.json.v3.codec.DecodeError
 import com.rojoma.json.v3.util.{AutomaticJsonCodecBuilder, JsonUtil}
 import com.socrata.http.server.HttpRequest
+import com.socrata.soda.clients.datacoordinator.DataCoordinatorClient.Cost
 import com.socrata.soda.server.highlevel.DatasetDAO
 import com.socrata.soda.server.id.{DatasetId, ResourceName}
 
 
-case class DCCollocateOperation(collocations: Seq[Seq[DatasetId]])
-case class SFCollocateOperation(collocations: Seq[Seq[ResourceName]])
+case class DCCollocateOperation(collocations: Seq[Seq[DatasetId]], limits: Cost)
+case class SFCollocateOperation(collocations: Seq[Seq[ResourceName]], limits: Cost)
 
 object SFCollocateOperation{
   private implicit val coCodec = AutomaticJsonCodecBuilder[SFCollocateOperation]
@@ -28,7 +29,7 @@ object DCCollocateOperation{
 
     if(translatedIds.forall(_.forall(_.isLeft))) {
       // Everything was able to be translated
-      Left(DCCollocateOperation(translatedIds.map(_.map(_.left.get))))
+      Left(DCCollocateOperation(translatedIds.map(_.map(_.left.get)), sfCollocate.limits))
     } else {
       // Just get the first error to propogate up
       Right(translatedIds.flatten.find(_.isRight).get.right.get)


### PR DESCRIPTION
Pass on cost limits to data-coordinator so data-coordinator
may reject collocation if the cost exceeds the passed limits.

Warning: this is a breaking change since the new fields in the
collocation request are required. Soda-fountain should be deployed
prior to data-coordinator to not cause errors.