### PR TITLE
SPARTA: Fix solo docker start script

### DIFF
--- a/bin/run_migrations.sh
+++ b/bin/run_migrations.sh
@@ -6,7 +6,7 @@ set -e
 REALPATH=$(python -c "import os; print(os.path.realpath('$0'))")
 BINDIR=$(dirname "$REALPATH")
 
-CONFIG="configs/application.conf"
+CONFIG="$BINDIR/../configs/application.conf"
 JARFILE=$("$BINDIR"/build.sh "$@")
 
 COMMAND=${1:-migrate}

--- a/bin/start_soda_fountain.sh
+++ b/bin/start_soda_fountain.sh
@@ -5,7 +5,7 @@ set -e
 REALPATH=$(python -c "import os; print(os.path.realpath('$0'))")
 BINDIR=$(dirname "$REALPATH")
 
-CONFIG="configs/application.conf"
+CONFIG="$BINDIR/../configs/application.conf"
 JARFILE=$("$BINDIR"/build.sh "$@")
 
 "$BINDIR"/run_migrations.sh

--- a/bin/start_soda_fountain_docker.sh
+++ b/bin/start_soda_fountain_docker.sh
@@ -6,7 +6,11 @@ if [ -z "$image" ]; then
   exit 1
 fi
 
+local_config_dir="$(dirname "$(realpath "$0")")/../configs"
+
 AWS_PROFILE=infrastructure docker run \
+           -e SERVER_CONFIG=/etc/configs/application.conf \
+           -v "$local_config_dir":/etc/configs \
            -p 6010:6010 \
            -d -t "$image"
 

--- a/docker/ship.d/run
+++ b/docker/ship.d/run
@@ -5,11 +5,12 @@ if [ -z "$MARATHON_APP_ID" ]; then
   echo "Not compiling j2 config file because this is not running in Marathon!"
 else
   /bin/env_parse ${SERVER_CONFIG}.j2
-  export CONFIG_LINE="-Dconfig.file=${SERVER_CONFIG}"  
 fi
 
+echo "Using config $SERVER_CONFIG"
+
 su socrata -c '/usr/bin/java \
-    $CONFIG_LINE \
+    -Dconfig.file=${SERVER_CONFIG} \
     -cp $SERVER_ARTIFACT \
     com.socrata.soda.server.MigrateSchema migrate'
 
@@ -17,7 +18,7 @@ exec su socrata -c '/usr/bin/java \
     -Xmx${JAVA_XMX} \
     -Xms${JAVA_XMX} \
     -XX:MaxMetaspaceSize=${JAVA_MAX_METASPACE} \
-    $CONFIG_LINE \
+    -Dconfig.file=${SERVER_CONFIG} \
     -Djava.net.preferIPv4Stack=true \
     -Dcom.sun.management.jmxremote.port=${JMX_PORT} \
     -Dcom.sun.management.jmxremote.rmi.port=${JMX_PORT} \


### PR DESCRIPTION
So that it actually uses the local development configs
in the configs directory.

Also, add full paths in the scripts in bin so
`solo start soda-fountain` can be run outside the soda-fountain
directory.