### PR TITLE
EN-27677: Pass through 429/503 status code.

### DIFF
--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/querycoordinator/HttpQueryCoordinatorClient.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/querycoordinator/HttpQueryCoordinatorClient.scala
@@ -93,6 +93,10 @@ trait HttpQueryCoordinatorClient extends QueryCoordinatorClient {
       case SC_REQUEST_TIMEOUT =>
         // if we can't read the timeout for some reason, pass through null but keep it as a RequestTimedOut
         response.value[RequestTimedOut]().right.toOption.getOrElse(RequestTimedOut(JNull))
+      case SC_SERVICE_UNAVAILABLE =>
+        ServiceUnavailable
+      case 429 =>
+        TooManyRequests
       case status =>
         val r = response.value[QueryCoordinatorError]().right.toOption.getOrElse(
           throw new Exception(s"Response was JSON but not decodable as an error -  query: $query; code $status"))

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/querycoordinator/QueryCoordinatorClient.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/querycoordinator/QueryCoordinatorClient.scala
@@ -23,6 +23,8 @@ object QueryCoordinatorClient {
   // Fail Cases
   case class NotModified(etags: Seq[EntityTag]) extends FailResult
   case object PreconditionFailed extends FailResult
+  case object ServiceUnavailable extends FailResult
+  case object TooManyRequests extends FailResult
   case class RequestTimedOut(timeout: JValue) extends FailResult
   object RequestTimedOut {
     implicit val jCodec = AutomaticJsonCodecBuilder[RequestTimedOut]

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/RowDAO.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/RowDAO.scala
@@ -73,6 +73,8 @@ object RowDAO {
   // FAILURE: QueryCoordinator
   case class PreconditionFailed(failure: Precondition.Failure) extends FailResult
   case class RequestTimedOut(timeout: JValue) extends FailResult
+  case object ServiceUnavailable extends FailResult
+  case object TooManyRequests extends FailResult
 
   // FAILURES: Internally consumed
   case object TooManyRows extends FailResult

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/RowDAOImpl.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/RowDAOImpl.scala
@@ -158,6 +158,10 @@ class RowDAOImpl(store: NameAndSchemaStore, dc: DataCoordinatorClient, qc: Query
         RowDAO.PreconditionFailed(Precondition.FailedBecauseNoMatch)
       case QueryCoordinatorClient.RequestTimedOut(timeout) =>
         RowDAO.RequestTimedOut(timeout)
+      case QueryCoordinatorClient.ServiceUnavailable =>
+        RowDAO.ServiceUnavailable
+      case QueryCoordinatorClient.TooManyRequests =>
+        RowDAO.TooManyRequests
       case QueryCoordinatorClient.QueryCoordinatorResult(status, result) =>
         RowDAO.QCError(status, result)
       case QueryCoordinatorClient.InternalServerErrorResult(status, code, tag, data) =>

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/Resource.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/Resource.scala
@@ -248,7 +248,12 @@ case class Resource(rowDAO: RowDAO,
                       "code"  -> JString(code),
                       "data" -> JString(data),
                       "tag" -> JString(tag)))
-
+                  case RowDAO.ServiceUnavailable =>
+                    metricByStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE)
+                    SodaUtils.response(req, SodaErrors.ServiceUnavailable)
+                  case RowDAO.TooManyRequests =>
+                    metricByStatus(429)
+                    SodaUtils.response(req, SodaErrors.TooManyRequests)
                 }
               case None =>
                 metric(QueryErrorUser)

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/responses/responses.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/responses/responses.scala
@@ -43,6 +43,14 @@ case class InternalException(th: Throwable, tag: String)
   override def excludedFields = Set("errorMessage", "errorClass", "stackTrace")
 }
 
+case object ServiceUnavailable
+  extends SodaResponse(SC_SERVICE_UNAVAILABLE, "service-unavailable",
+    "Service unavailable")
+
+case object TooManyRequests
+  extends SodaResponse(429, "too-many-requests",
+      "Too many requests")
+
 case class SodaInvalidRequest(th: Throwable, tag: String)
   extends SodaResponse(SC_BAD_REQUEST, "invalid-request",
     s"Invalid request: ${Option(th.getMessage).getOrElse("")}",


### PR DESCRIPTION
This is to allow for the load shedding per dataset concurrency limit
changes in https://github.com/socrata-platform/soql-postgres-adapter/pull/284 to
pass a reasonable HTTP status code back.

This is mostly sidestepping the whole complicated and unfinished
soda fountain error code infrastructure in favor of standardized
HTTP status codes.

We only need 429 for the load shedding work, but I implemented 503
first before I changed my mind and went with 429, and think 503 is
valuable to pass back in general instead of the previous behavior
of turning the 503 into a generic 500 if it didn't have a json
response body.