### PR TITLE
The datasets table has unused columns, ignore them

### DIFF
--- a/soda-fountain-lib/src/main/resources/com/socrata/soda/server/persistence/pg/20190408-give-defaults-to-obsolete-datasets-columns.xml
+++ b/soda-fountain-lib/src/main/resources/com/socrata/soda/server/persistence/pg/20190408-give-defaults-to-obsolete-datasets-columns.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <changeSet author="robertm" id="20190408-give-defaults-to-obsolete-datasets-columns">
+        <sql>
+          ALTER TABLE datasets ALTER COLUMN schema_hash SET DEFAULT '', ALTER COLUMN primary_key_column_id SET DEFAULT ''
+        </sql>
+    </changeSet>
+</databaseChangeLog>

--- a/soda-fountain-lib/src/main/resources/com/socrata/soda/server/persistence/pg/migrate.xml
+++ b/soda-fountain-lib/src/main/resources/com/socrata/soda/server/persistence/pg/migrate.xml
@@ -17,4 +17,5 @@
     <include file="com/socrata/soda/server/persistence/pg/20170712-add-datasets-deleted-at-index.xml"/>
     <include file="com/socrata/soda/server/persistence/pg/20171006-increase-column-name-size.xml"/>
     <include file="com/socrata/soda/server/persistence/pg/20181023-add-indexes.xml"/>
+    <include file="com/socrata/soda/server/persistence/pg/20190408-give-defaults-to-obsolete-datasets-columns.xml"/>
 </databaseChangeLog>

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/datacoordinator/DataCoordinatorClient.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/datacoordinator/DataCoordinatorClient.scala
@@ -31,7 +31,7 @@ object DataCoordinatorClient {
     implicit val codec = SimpleJsonCodecBuilder[VersionReport].build("version", _.version)
   }
 
-  case class ReportMetaData(val datasetId: DatasetId, val version: Long, val lastModified: DateTime)
+  case class ReportMetaData(val datasetId: DatasetId, val copyNumber: Long, val version: Long, val lastModified: DateTime)
 
   sealed abstract class ReportItem
   case class UpsertReportItem(data: Iterator[JValue] /* Note: this MUST be completely consumed before calling hasNext/next on parent iterator! */) extends ReportItem

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/datacoordinator/HttpDataCoordinatorClient.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/datacoordinator/HttpDataCoordinatorClient.scala
@@ -332,6 +332,7 @@ abstract class HttpDataCoordinatorClient(httpClient: HttpClient) extends DataCoo
             throw new Exception("Bad response from data coordinator: expected dataset id")
           val StringEvent(datasetId) = events.next()
           (ReportMetaData(DatasetId(datasetId),
+                          getHeader(xhCopyNumber, r).toLong,
                           getHeader(xhDataVersion, r).toLong,
                           dateTimeParser.parseDateTime(getHeader(xhLastModified, r))),
            arrayOfResults(events, alreadyInArray = true).toSeq)

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/ColumnDAOImpl.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/ColumnDAOImpl.scala
@@ -145,7 +145,7 @@ class ColumnDAOImpl(dc: DataCoordinatorClient,
                     store.updateVersionInfo(datasetRecord.systemId, newVersion, lastModified, None, copyNumber, None)
                     ColumnDAO.Updated(columnRecord, None)
                   case DataCoordinatorClient.SchemaOutOfDateResult(newSchema) =>
-                    store.resolveSchemaInconsistency(datasetRecord.systemId, newSchema)
+                    store.resolveSchemaInconsistency(datasetRecord.systemId, datasetRecord.copyNumber, newSchema)
                     retry()
                   case DataCoordinatorClient.DuplicateValuesInColumnResult(_, _, _) =>
                     ColumnDAO.DuplicateValuesInColumn(columnRecord)
@@ -271,7 +271,7 @@ class ColumnDAOImpl(dc: DataCoordinatorClient,
 
             ColumnDAO.Updated(updatedColumnRec, etag)
           case DataCoordinatorClient.SchemaOutOfDateResult(realSchema) =>
-            store.resolveSchemaInconsistency(datasetRecord.systemId, realSchema)
+            store.resolveSchemaInconsistency(datasetRecord.systemId, datasetRecord.copyNumber, realSchema)
             retry()
           case DataCoordinatorClient.DuplicateValuesInColumnResult(_, _, _) =>
             ColumnDAO.DuplicateValuesInColumn(columnRecord)
@@ -335,7 +335,7 @@ class ColumnDAOImpl(dc: DataCoordinatorClient,
                                             None)
                     ColumnDAO.Deleted(columnRef, etag)
                   case DataCoordinatorClient.SchemaOutOfDateResult(realSchema) =>
-                    store.resolveSchemaInconsistency(datasetRecord.systemId, realSchema)
+                    store.resolveSchemaInconsistency(datasetRecord.systemId, datasetRecord.copyNumber, realSchema)
                     retry()
                   case DataCoordinatorClient.DuplicateValuesInColumnResult(_, _, _) =>
                     ColumnDAO.DuplicateValuesInColumn(columnRef)

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/DatasetDAOImpl.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/DatasetDAOImpl.scala
@@ -197,7 +197,7 @@ class DatasetDAOImpl(dc: DataCoordinatorClient,
               store.removeResource(dataset)
               Deleted
             case DataCoordinatorClient.SchemaOutOfDateResult(newSchema) =>
-              store.resolveSchemaInconsistency(datasetRecord.systemId, newSchema)
+              store.resolveSchemaInconsistency(datasetRecord.systemId, datasetRecord.copyNumber, newSchema)
               retry()
               // should only have two error case for this path.
             case DataCoordinatorClient.DatasetNotFoundResult(_) =>
@@ -303,7 +303,7 @@ class DatasetDAOImpl(dc: DataCoordinatorClient,
               store.makeCopy(datasetRecord.systemId, newCopyNumber, newVersion)
               WorkingCopyCreated
             case DataCoordinatorClient.SchemaOutOfDateResult(newSchema) =>
-              store.resolveSchemaInconsistency(datasetRecord.systemId, newSchema)
+              store.resolveSchemaInconsistency(datasetRecord.systemId, datasetRecord.copyNumber, newSchema)
               retry()
             case DataCoordinatorClient.DatasetNotFoundResult(_) =>
               DatasetNotFound(dataset)
@@ -337,7 +337,7 @@ class DatasetDAOImpl(dc: DataCoordinatorClient,
                   store.updateVersionInfo(datasetRecord.systemId, newVersion, lastModified, Some(Discarded), unpublishCopyNumber, None)
                   WorkingCopyDropped
                 case DataCoordinatorClient.SchemaOutOfDateResult(newSchema) =>
-                  store.resolveSchemaInconsistency(datasetRecord.systemId, newSchema)
+                  store.resolveSchemaInconsistency(datasetRecord.systemId, datasetRecord.copyNumber, newSchema)
                   retry()
                 case DataCoordinatorClient.DatasetNotFoundResult(_) =>
                   DatasetNotFound(dataset)
@@ -369,7 +369,7 @@ class DatasetDAOImpl(dc: DataCoordinatorClient,
               store.updateVersionInfo(datasetRecord.systemId, newVersion, lastModified, Some(Published), copyNumber, Some(0))
               WorkingCopyPublished
             case DataCoordinatorClient.SchemaOutOfDateResult(newSchema) =>
-              store.resolveSchemaInconsistency(datasetRecord.systemId, newSchema)
+              store.resolveSchemaInconsistency(datasetRecord.systemId, datasetRecord.copyNumber, newSchema)
               retry()
             case DataCoordinatorClient.DatasetNotFoundResult(_) =>
               DatasetNotFound(dataset)

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/ExportDAOImpl.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/ExportDAOImpl.scala
@@ -80,7 +80,7 @@ class ExportDAOImpl(store: NameAndSchemaStore, dc: DataCoordinatorClient) extend
               )
               ExportDAO.Success(simpleSchema, etag, decodedSchema.rows)
             case DataCoordinatorClient.SchemaOutOfDateResult(newSchema) =>
-              store.resolveSchemaInconsistency(ds.systemId, newSchema)
+              store.resolveSchemaInconsistency(ds.systemId, ds.copyNumber, newSchema)
               retry()
             case DataCoordinatorClient.NotModifiedResult(etags) =>
               ExportDAO.NotModified(etags)

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/RowDAOImpl.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/RowDAOImpl.scala
@@ -190,7 +190,7 @@ class RowDAOImpl(store: NameAndSchemaStore, dc: DataCoordinatorClient, qc: Query
         // that SHOULD occur with only low probability that's pretty expensive.
         //
         // I guess we'll refresh our own schema and then toss an error to the user?
-        store.resolveSchemaInconsistency(datasetRecord.systemId, newSchema)
+        store.resolveSchemaInconsistency(datasetRecord.systemId, datasetRecord.copyNumber, newSchema)
         f(SchemaOutOfSync)
       case DataCoordinatorClient.NoSuchRowResult(id, _) =>
         f(RowNotFound(id))

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/package.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/package.scala
@@ -59,6 +59,7 @@ package object highlevel {
         SchemaHash.computeHash(__underlying.locale, __underlying.columns(__underlying.rowIdentifier).id, columns),
         __underlying.columns(__underlying.rowIdentifier).id,
         columns,
+        dsMetaData.copyNumber,
         dsMetaData.version,
         __underlying.stage,
         dsMetaData.lastModified)

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/persistence/NameAndSchemaStore.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/persistence/NameAndSchemaStore.scala
@@ -36,7 +36,7 @@ trait NameAndSchemaStore {
    * Return all copies most recent first
    */
   def lookupDataset(resourceName: ResourceName): Seq[DatasetRecord]
-  def resolveSchemaInconsistency(datasetId: DatasetId, newSchema: SchemaSpec)
+  def resolveSchemaInconsistency(datasetId: DatasetId, copyNumber: Long, newSchema: SchemaSpec)
 
   def setPrimaryKey(datasetId: DatasetId, pkCol: ColumnId, copyNumber: Long)
 
@@ -68,6 +68,7 @@ trait DatasetRecordLike {
   val locale: String
   val schemaHash: String
   val primaryKey: ColumnId
+  val copyNumber: Long
   val truthVersion: Long
   val stage: Option[Stage]
   val lastModified: DateTime
@@ -109,6 +110,7 @@ case class MinimalDatasetRecord(
   schemaHash: String,
   primaryKey: ColumnId,
   columns: Seq[MinimalColumnRecord],
+  copyNumber: Long,
   truthVersion: Long,
   stage: Option[Stage],
   lastModified: DateTime,
@@ -134,6 +136,7 @@ case class DatasetRecord(
   schemaHash: String,
   primaryKey: ColumnId,
   columns: Seq[ColumnRecord],
+  copyNumber: Long,
   truthVersion: Long,
   stage: Option[Stage],
   lastModified: DateTime,

--- a/soda-fountain-lib/src/test/scala/com/socrata/soda/server/DatasetsForTesting.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/soda/server/DatasetsForTesting.scala
@@ -32,6 +32,7 @@ trait DatasetsForTesting {
       new ColumnId("mock column id"),
       columns,
       0,
+      0,
       None,
       new DateTime(0))
   }
@@ -76,6 +77,7 @@ trait DatasetsForTesting {
       "095c0a28ba0a9a0e58f22bf456fc82d27853c1b9",
       new ColumnId(":id"),
       Seq(idColumn, sourceColumn, computedColumn),
+      1,
       9,
       None,
       DateTime.now

--- a/soda-fountain-lib/src/test/scala/com/socrata/soda/server/persistence/PostgresStoreTest.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/soda/server/persistence/PostgresStoreTest.scala
@@ -20,7 +20,7 @@ class PostgresStoreTest extends SodaFountainDatabaseTest with ShouldMatchers wit
 
     val foundRecord = store.translateResourceName(resourceName)
     foundRecord match {
-      case Some(MinimalDatasetRecord(rn, did, loc, sch, pky, cols, _, stage, _, _)) =>
+      case Some(MinimalDatasetRecord(rn, did, loc, sch, pky, cols, _, _, stage, _, _)) =>
         stage should equal (Some(Unpublished))
         rn should equal (resourceName)
         did should equal (datasetId)
@@ -56,7 +56,7 @@ class PostgresStoreTest extends SodaFountainDatabaseTest with ShouldMatchers wit
 
     val f = store.translateResourceName(resourceName)
     f match {
-      case Some(MinimalDatasetRecord(rn, did, loc, sch, pky, Seq(MinimalColumnRecord(col1, _, _, _, None), MinimalColumnRecord(col2, _, _, _, None)), _, _, _, _)) =>
+      case Some(MinimalDatasetRecord(rn, did, loc, sch, pky, Seq(MinimalColumnRecord(col1, _, _, _, None), MinimalColumnRecord(col2, _, _, _, None)), _, _, _, _, _)) =>
         col1 should equal (ColumnId("abc123"))
         col2 should equal (ColumnId("def456"))
       case None => fail("didn't find columns")
@@ -78,7 +78,7 @@ class PostgresStoreTest extends SodaFountainDatabaseTest with ShouldMatchers wit
     val f = store.translateResourceName(resourceName)
     f match {
       case Some(MinimalDatasetRecord(rn, did, loc, sch, pky,
-        Seq(MinimalColumnRecord(columnId, columnName, _, _, _)), _, _, _, _)) =>
+        Seq(MinimalColumnRecord(columnId, columnName, _, _, _)), _, _, _, _, _)) =>
         columnId should be (ColumnId("one"))
         columnName should be (ColumnName("new_field_name"))
       case None => fail("didn't find columns")

--- a/soda-fountain-lib/src/test/scala/com/socrata/soda/server/persistence/PostgresStoreTest.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/soda/server/persistence/PostgresStoreTest.scala
@@ -301,7 +301,7 @@ class PostgresStoreTest extends SodaFountainDatabaseTest with ShouldMatchers wit
     store.makeCopy(datasetId, 3L, 3L)
     store.addColumn(datasetId, 3L, columnSpecs(2))
     store.addColumn(datasetId, 3L, columnSpecs(3))
-    store.dropColumn(datasetId, ColumnId("four"), 3L)
+    store.dropColumn(datasetId, ColumnId("four"), 3L, ColumnId(":id"))
 
     val publishedCopy = store.lookupDataset(resourceName, Some(Published))
     publishedCopy should not be (None)

--- a/soda-fountain-lib/src/test/scala/com/socrata/soda/server/resources/SuggestTest.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/soda/server/resources/SuggestTest.scala
@@ -46,7 +46,7 @@ class SuggestTest extends SpandexTestSuite with Matchers with MockFactory with T
 
   val datasetRecord = new DatasetRecord(
     resourceName, new DatasetId(expectedDatasetId),
-    "", "", "", "", new ColumnId(""), Seq.empty, 0L, None, DateTime.now()
+    "", "", "", "", new ColumnId(""), Seq.empty, 0L, 0L, None, DateTime.now()
   )
   val columnRecord = new ColumnRecord(
     new ColumnId(expectedColumnId), columnName,


### PR DESCRIPTION
The primary key and schema hash columns are written to but henceforth
almost ignored, so make them ignorable.  Future update once this is
out will actually drop them.

The resolveSchemaInconsistency method actually used them, but it was
incorrect to do so.  I've changed it so it operates on a particular
copy, which is what it should have been doing all along.