### PR TITLE
EN-30766 allow writes to be gated on data version

### DIFF
--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/datacoordinator/DataCoordinatorClient.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/datacoordinator/DataCoordinatorClient.scala
@@ -100,6 +100,7 @@ object DataCoordinatorClient {
   case class InitialCopyDropResult(datasetId: DatasetId, commandIndex: Long) extends FailResult
   case class OperationAfterDropResult(datasetId: DatasetId, commandIndex: Long) extends FailResult
   case class FeedbackInProgressResult(datasetId: DatasetId, commandIndex: Long, stores: Set[String]) extends FailResult
+  case class DatasetVersionMismatchResult(dataset: DatasetId, version: Long) extends FailResult
 
   // FAIL CASES: Updates
   case class NotPrimaryKeyResult(datasetId: DatasetId, columnId: ColumnId, commandIndex: Long) extends FailResult
@@ -142,6 +143,7 @@ trait DataCoordinatorClient {
 
   def update[T](datasetId: DatasetId,
                 schemaHash: String,
+                expectedDataVersion: Option[Long],
                 user: String,
                 instructions: Iterator[DataCoordinatorInstruction],
                 extraHeaders: Map[String, String] = Map.empty)
@@ -149,6 +151,7 @@ trait DataCoordinatorClient {
 
   def copy[T](datasetId: DatasetId,
               schemaHash: String,
+              expectedDataVersion: Option[Long],
               copyData: Boolean,
               user: String,
               instructions: Iterator[DataCoordinatorInstruction] = Iterator.empty,
@@ -157,6 +160,7 @@ trait DataCoordinatorClient {
 
   def publish[T](datasetId: DatasetId,
                  schemaHash: String,
+                 expectedDataVersion: Option[Long],
                  keepSnapshot:Option[Boolean],
                  user: String,
                  instructions: Iterator[DataCoordinatorInstruction] = Iterator.empty,
@@ -165,6 +169,7 @@ trait DataCoordinatorClient {
 
   def dropCopy[T](datasetId: DatasetId,
                   schemaHash: String,
+                  expectedDataVersion: Option[Long],
                   user: String,
                   instructions: Iterator[DataCoordinatorInstruction] = Iterator.empty,
                   extraHeaders: Map[String, String] = Map.empty)
@@ -172,6 +177,7 @@ trait DataCoordinatorClient {
 
   def deleteAllCopies[T](datasetId: DatasetId,
                          schemaHash: String,
+                         expectedDataVersion: Option[Long],
                          user: String,
                          extraHeaders: Map[String, String] = Map.empty)
                         (f: Result => T): T

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/datacoordinator/DataCoordinatorErrors.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/datacoordinator/DataCoordinatorErrors.scala
@@ -65,10 +65,14 @@ case class InvalidRowId() extends DCRequestError
 // Request Errors: Script Header
 
 @Tag("req.script.header.mismatched-schema")
-case class SchemaMismatch(dataset: DatasetId, schema: SchemaSpec, commandIndex: Long) extends DCRequestError
+case class SchemaMismatch(dataset: DatasetId, schema: SchemaSpec) extends DCRequestError
 
 @Tag("req.script.header.missing")
-case class EmptyCommandStream(commandIndex: Long) extends DCRequestError
+case class EmptyCommandStream() extends DCRequestError
+
+@Tag("req.script.header.mismatched-data-version")
+case class DatasetVersionMismatch(dataset: DatasetId,
+                                  version: Long) extends DCUpdateError
 
 // Request Errors: Script Command
 
@@ -90,7 +94,6 @@ case class SystemInReadOnlyMode(commandIndex: Long) extends DCUpdateError
 
 @Tag("update.type.unknown")
 case class NoSuchType(`type`: String, commandIndex: Long) extends DCUpdateError
-
 
 @Tag("update.row-version-mismatch")
 case class RowVersionMismatch(dataset: DatasetId,

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/datacoordinator/DatasetCopyInstruction.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/datacoordinator/DatasetCopyInstruction.scala
@@ -5,7 +5,7 @@ import com.socrata.soda.server.id.ResourceName
 sealed abstract class DatasetCopyInstruction { val command: String}
 
 case class CreateDataset(resource: ResourceName, locale: String = "en_US") extends DatasetCopyInstruction { val command = "create"}
-case class CopyDataset(copyData: Boolean, schema: String) extends DatasetCopyInstruction { val command = "copy"}
-case class PublishDataset(keepSnapshot: Option[Boolean], schema: String) extends DatasetCopyInstruction { val command = "publish"}
-case class DropDataset(schema: String) extends DatasetCopyInstruction { val command = "drop"}
-case class UpdateDataset(schema: String) extends DatasetCopyInstruction { val command = "normal"}
+case class CopyDataset(copyData: Boolean, schema: String, expectedDataVersion: Option[Long]) extends DatasetCopyInstruction { val command = "copy"}
+case class PublishDataset(keepSnapshot: Option[Boolean], schema: String, expectedDataVersion: Option[Long]) extends DatasetCopyInstruction { val command = "publish"}
+case class DropDataset(schema: String, expectedDataVersion: Option[Long]) extends DatasetCopyInstruction { val command = "drop"}
+case class UpdateDataset(schema: String, expectedDataVersion: Option[Long]) extends DatasetCopyInstruction { val command = "normal"}

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/SodaFountain.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/SodaFountain.scala
@@ -237,7 +237,7 @@ class SodaFountain(config: SodaFountainConfig) extends Closeable {
           records.foreach { rec =>
             log.info(s"Dropping dataset ${rec.resourceName} (${rec.systemId}")
             //drops the dataset and calls data coordinator to remove datasets in truth
-            datasetDAO.removeDataset("", rec.resourceName, RequestId.generate())
+            datasetDAO.removeDataset("", rec.resourceName, None, RequestId.generate())
           }
         }
         catch {

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/ColumnDAO.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/ColumnDAO.scala
@@ -14,15 +14,16 @@ trait ColumnDAO {
   def replaceOrCreateColumn(user: String,
                             dataset: ResourceName,
                             precondition: Precondition,
+                            expectedDataVersion: Option[Long],
                             column: ColumnName,
                             spec: UserProvidedColumnSpec,
                             requestId: RequestId): Result
 
-  def updateColumn(user: String, dataset: ResourceName, column: ColumnName, spec: UserProvidedColumnSpec, requestId: RequestId): Result
+  def updateColumn(user: String, dataset: ResourceName, expectedDataVersion: Option[Long], column: ColumnName, spec: UserProvidedColumnSpec, requestId: RequestId): Result
 
-  def deleteColumn(user: String, dataset: ResourceName, column: ColumnName, requestId: RequestId): Result
+  def deleteColumn(user: String, dataset: ResourceName, expectedDataVersion: Option[Long], column: ColumnName, requestId: RequestId): Result
 
-  def makePK(user: String, dataset: ResourceName, column: ColumnName, requestId: RequestId): Result
+  def makePK(user: String, dataset: ResourceName, expectedDataVersion: Option[Long], column: ColumnName, requestId: RequestId): Result
 
   def getColumn(dataset: ResourceName, column: ColumnName): Result
 }
@@ -48,6 +49,7 @@ object ColumnDAO {
   case class InternalServerError(code: String, tag: String, data: String) extends FailResult
   case class CannotDeleteRowId(columnRec: ColumnRecord, method: String) extends FailResult
   case class DatasetNotFound(dataset: ResourceName) extends FailResult
+  case class DatasetVersionMismatch(dataset: ResourceName, version: Long) extends FailResult
   case object CannotChangeColumnId extends FailResult
   case object CannotChangeColumnType extends FailResult
 

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/DatasetDAO.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/DatasetDAO.scala
@@ -24,28 +24,29 @@ trait DatasetDAO {
                     requestId: RequestId): Result
   def markDatasetForDeletion(user: String, dataset: ResourceName): Result
   def unmarkDatasetForDeletion(user: String, dataset: ResourceName) : Result
-  def removeDataset(user: String, dataset: ResourceName, requestId: RequestId): Result
+  def removeDataset(user: String, dataset: ResourceName, expectedDataVersion: Option[Long], requestId: RequestId): Result
   def getDataset(dataset: ResourceName, stage: Option[Stage]): Result
   def getSecondaryVersions(dataset: ResourceName, requestId: RequestId): Result
   def getVersion(dataset: ResourceName, secondary: SecondaryId, requestId: RequestId): Result
   def getCurrentCopyNum(dataset: ResourceName): Option[Long]
 
-  def makeCopy(user: String, dataset: ResourceName, copyData: Boolean, requestId: RequestId): Result
-  def dropCurrentWorkingCopy(user: String, dataset: ResourceName, requestId: RequestId): Result
-  def publish(user: String, dataset: ResourceName, keepSnapshot: Option[Boolean], requestId: RequestId): Result
+  def makeCopy(user: String, dataset: ResourceName, expectedDataVersion: Option[Long], copyData: Boolean, requestId: RequestId): Result
+  def dropCurrentWorkingCopy(user: String, dataset: ResourceName, expectedDataVersion: Option[Long], requestId: RequestId): Result
+  def publish(user: String, dataset: ResourceName, expectedDataVersion: Option[Long], keepSnapshot: Option[Boolean], requestId: RequestId): Result
   def propagateToSecondary(dataset: ResourceName, secondary: SecondaryId, requestId: RequestId): Result
 
   def replaceOrCreateRollup(user: String,
                             dataset: ResourceName,
+                            expectedDataVersion: Option[Long],
                             rollup: RollupName,
                             spec: UserProvidedRollupSpec,
                             requestId: RequestId): Result
   def getRollups(dataset: ResourceName, requestId: RequestId): Result
-  def deleteRollup(user: String, dataset: ResourceName, rollup: RollupName, requestId: RequestId): Result
+  def deleteRollup(user: String, dataset: ResourceName, expectedDataVersion: Option[Long],rollup: RollupName, requestId: RequestId): Result
   def collocate(secondaryId: SecondaryId, operation: SFCollocateOperation, explain: Boolean, jobId: String): Result
   def collocateStatus(dataset: ResourceName, secondaryId: SecondaryId, jobId: String): Result
   def deleteCollocate(dataset: ResourceName, secondaryId: SecondaryId, jobId: String): Result
-  def secondaryReindex(user: String, dataset: ResourceName): Result
+  def secondaryReindex(user: String, dataset: ResourceName, expectedDataVersion: Option[Long]): Result
 }
 
 object DatasetDAO {
@@ -114,6 +115,7 @@ object DatasetDAO {
   // FAILURES: DataCoordinator
   case class RollupNotFound(name: RollupName) extends FailResult
   case class DatasetNotFound(name: ResourceName) extends FailResult
+  case class DatasetVersionMismatch(name: ResourceName, version: Long) extends FailResult
   case class CannotAcquireDatasetWriteLock(name: ResourceName) extends FailResult
   case class FeedbackInProgress(name: ResourceName, stores: Set[String]) extends FailResult
   case class IncorrectLifecycleStageResult(actualStage: String, expectedStage: Set[String]) extends FailResult

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/RowDAO.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/RowDAO.scala
@@ -49,15 +49,16 @@ trait RowDAO {
 
   def upsert[T](user: String,
                 datasetRecord: DatasetRecordLike,
+                expectedDataVersion: Option[Long],
                 data: Iterator[RowUpdate],
                 requestId: RequestId,
                 rowUpdateOption: RowUpdateOption = RowUpdateOption.default)
                (f: UpsertResult => T): T
 
-  def replace[T](user: String, datasetRecord: DatasetRecordLike, data: Iterator[RowUpdate], requestId: RequestId)
+  def replace[T](user: String, datasetRecord: DatasetRecordLike, expectedDataVersion: Option[Long], data: Iterator[RowUpdate], requestId: RequestId)
                 (f: UpsertResult => T): T
 
-  def deleteRow[T](user: String, dataset: ResourceName, rowId: RowSpecifier, requestId: RequestId)
+  def deleteRow[T](user: String, dataset: ResourceName, expectedDataVersion: Option[Long], rowId: RowSpecifier, requestId: RequestId)
                   (f: UpsertResult => T): T
 }
 
@@ -103,6 +104,7 @@ object RowDAO {
   case object DeleteWithoutPrimaryKey extends UpsertFailResult
   case class InvalidRequest(client: String, status: Int, body: JValue) extends UpsertFailResult
   case class RowNotAnObject(value: JValue) extends UpsertFailResult
+  case class DatasetVersionMismatch(dataset: ResourceName, version: Long) extends UpsertFailResult
   case class InternalServerError(status: Int = 500, client: String = "QC", code: String, tag: String, data: String) extends UpsertFailResult
 
   // UPSERT FAILURE: QueryCoordinator

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/SodaResource.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/SodaResource.scala
@@ -27,8 +27,18 @@ class SodaResource extends SimpleResource {
       case Some(v) => Header(header, v)
       case None => Function.const(())
     }
+
+  def expectedDataVersion(req: HttpRequest): Option[Long] =
+    try {
+      req.header("X-SODA2-Truth-Version").map(_.toLong)
+    } catch {
+      case e: NumberFormatException =>
+        SodaResource.log.warn("Unparsable expected data version")
+        None
+    }
 }
 
 object SodaResource {
   private val log = org.slf4j.LoggerFactory.getLogger(classOf[SodaResource])
+
 }

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/UpsertUtils.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/UpsertUtils.scala
@@ -63,6 +63,8 @@ object UpsertUtils {
         SodaUtils.response(request, SodaErrors.UpsertRowNotAnObject(obj))(response)
       case RowDAO.DatasetNotFound(dataset) =>
         SodaUtils.response(request, SodaErrors.DatasetNotFound(dataset))(response)
+      case RowDAO.DatasetVersionMismatch(dataset, version) =>
+        SodaUtils.response(request, SodaErrors.DatasetVersionMismatch(dataset, version))(response)
       case RowDAO.SchemaOutOfSync =>
         SodaUtils.response(request, SodaErrors.SchemaInvalidForMimeType)(response)
       case RowDAO.InvalidRequest(client, status, body) =>

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/responses/responses.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/responses/responses.scala
@@ -209,6 +209,13 @@ case class DatasetNameInvalidNameSodaErr(dataset:  ResourceName)
   extends SodaResponse(SC_BAD_REQUEST, "soda.dataset.invalid-Name",
     s"Dataset name '${dataset.name}' is invalid",
     "dataset" -> JString(dataset.name))
+
+case class DatasetVersionMismatch(dataset: ResourceName, version: Long)
+  extends SodaResponse(SC_CONFLICT, "soda.row.dataset-version-mismatch",
+    s"The dataset does not have the required version",
+    "dataset" -> JString(dataset.name),
+    "version" -> JNumber(version))
+
 /**
  * Column not found in a row operation
  */

--- a/soda-fountain-lib/src/test/scala/com/socrata/datacoordinator/client/MutationScriptTest.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/datacoordinator/client/MutationScriptTest.scala
@@ -29,8 +29,8 @@ class MutationScriptTest extends DataCoordinatorClientTest {
   }
 
   test("Mutation Script compiles and runs"){
-    val mc = new MutationScript(user, UpdateDataset(schemaString), Array().iterator)
-    val expected = """[{c:'normal',  user:'Daniel the tester', schema:'fake_schema_hash'}]"""
+    val mc = new MutationScript(user, UpdateDataset(schemaString, Some(5)), Array().iterator)
+    val expected = """[{c:'normal',  user:'Daniel the tester', schema:'fake_schema_hash', data_version: 5}]"""
     testCompare(mc, expected)
   }
 
@@ -38,11 +38,11 @@ class MutationScriptTest extends DataCoordinatorClientTest {
     val cm = new AddColumnInstruction(numberType, fieldName, columnId, None)
     val mc = new MutationScript(
       user,
-      UpdateDataset(schemaString),
+      UpdateDataset(schemaString, Some(11001001)),
       Array(cm).iterator)
     val expected =
       """[
-        | {c:'normal',  user:'Daniel the tester', schema:'fake_schema_hash'},
+        | {c:'normal',  user:'Daniel the tester', schema:'fake_schema_hash', data_version: 11001001},
         | {c:'add column', field_name:'field_name', type:'number', id:'a column id'}
         |]""".stripMargin
     testCompare(mc, expected)
@@ -52,11 +52,11 @@ class MutationScriptTest extends DataCoordinatorClientTest {
     val cm = new AddColumnInstruction(numberType, fieldName, columnId, Some(computationStrategy))
     val mc = new MutationScript(
       user,
-      UpdateDataset(schemaString),
+      UpdateDataset(schemaString, Some(6)),
       Array(cm).iterator)
     val expected =
       """[
-        | {c:'normal',  user:'Daniel the tester', schema:'fake_schema_hash'},
+        | {c:'normal',  user:'Daniel the tester', schema:'fake_schema_hash', data_version: 6},
         | {c:'add column', field_name:'field_name', type:'number', id:'a column id', computation_strategy:{
         |  strategy_type:'test',
         |  source_column_ids:['source column id'],
@@ -70,11 +70,11 @@ class MutationScriptTest extends DataCoordinatorClientTest {
     val ru = new UpsertRow(Map("a" -> JString("aaa"), "b" -> JString("bbb")))
     val mc = new MutationScript(
       user,
-      UpdateDataset(schemaString),
+      UpdateDataset(schemaString, Some(7)),
       Array(ru).iterator)
     val expected =
       """[
-        | {c:'normal',  user:'Daniel the tester', schema:'fake_schema_hash'},
+        | {c:'normal',  user:'Daniel the tester', schema:'fake_schema_hash', data_version: 7},
         | {c:'row data',"truncate":false,"update":"merge","nonfatal_row_errors":[]},
         | {a:'aaa', b:'bbb'}
         |]""".stripMargin
@@ -85,11 +85,11 @@ class MutationScriptTest extends DataCoordinatorClientTest {
     val ru = new DeleteRow(new JString("row id string"))
     val mc = new MutationScript(
       user,
-      UpdateDataset(schemaString),
+      UpdateDataset(schemaString, Some(8)),
       Array(ru).iterator)
     val expected =
       """[
-        | {c:'normal',  user:'Daniel the tester', schema:'fake_schema_hash'},
+        | {c:'normal',  user:'Daniel the tester', schema:'fake_schema_hash', data_version: 8},
         | {c:'row data',"truncate":false,"update":"merge","nonfatal_row_errors":[]},
         | ['row id string']
         |]""".stripMargin
@@ -100,11 +100,11 @@ class MutationScriptTest extends DataCoordinatorClientTest {
     val dropRollup = new DropRollupInstruction(new RollupName("clown_type"))
     val mc = new MutationScript(
       user,
-      UpdateDataset(schemaString),
+      UpdateDataset(schemaString, Some(9)),
       Array(dropRollup).iterator)
     val expected =
       """[
-        | {c:'normal',  user:'Daniel the tester', schema:'fake_schema_hash'},
+        | {c:'normal',  user:'Daniel the tester', schema:'fake_schema_hash', data_version: 9},
         | {c:'drop rollup',"name":"clown_type"}
         |]""".stripMargin
     testCompare(mc, expected)
@@ -115,11 +115,11 @@ class MutationScriptTest extends DataCoordinatorClientTest {
     val ru = new UpsertRow(Map("a" -> JString("aaa"), "b" -> JString("bbb")))
     val mc = new MutationScript(
       user,
-      UpdateDataset(schemaString),
+      UpdateDataset(schemaString, Some(10)),
       Array(cm, ru).iterator)
     val expected =
       """[
-        | {c:'normal',  user:'Daniel the tester', schema:'fake_schema_hash'},
+        | {c:'normal',  user:'Daniel the tester', schema:'fake_schema_hash', data_version: 10},
         | {c:'add column', field_name:'field_name', type:'number', id:'a column id'},
         | {c:'row data',"truncate":false,"update":"merge","nonfatal_row_errors":[]},
         | {a:'aaa', b:'bbb'}
@@ -132,11 +132,11 @@ class MutationScriptTest extends DataCoordinatorClientTest {
     val cm = new AddColumnInstruction(numberType, fieldName, columnId, None)
     val mc = new MutationScript(
       user,
-      UpdateDataset(schemaString),
+      UpdateDataset(schemaString, Some(11)),
       Array(ru, cm).iterator)
     val expected =
       """[
-        | {c:'normal',  user:'Daniel the tester', schema:'fake_schema_hash'},
+        | {c:'normal',  user:'Daniel the tester', schema:'fake_schema_hash', data_version: 11},
         | {c:'row data',"truncate":false,"update":"merge","nonfatal_row_errors":[]},
         | {a:'aaa'},
         | null,
@@ -150,11 +150,11 @@ class MutationScriptTest extends DataCoordinatorClientTest {
     val ru = new UpsertRow(Map("a" -> JString("aaa")))
     val mc = new MutationScript(
       user,
-      UpdateDataset(schemaString),
+      UpdateDataset(schemaString, Some(12)),
       Array(roc, ru).iterator)
     val expected =
       """[
-        | {c:'normal',  user:'Daniel the tester', schema:'fake_schema_hash'},
+        | {c:'normal',  user:'Daniel the tester', schema:'fake_schema_hash', data_version: 12},
         | {c:'row data',"truncate":true,"update":"replace","fatal_row_errors":false},
         | {a:'aaa'}
         |]""".stripMargin
@@ -193,11 +193,11 @@ class MutationScriptTest extends DataCoordinatorClientTest {
     val ru = new UpsertRow(Map("a" -> JString("aaa")))
     val mc = new MutationScript(
       user,
-      UpdateDataset(schemaString),
+      UpdateDataset(schemaString, Some(13)),
       Array(roc1,roc2,ru).iterator)
     val expected =
       """[
-        | {c:'normal',  user:'Daniel the tester', schema:'fake_schema_hash'},
+        | {c:'normal',  user:'Daniel the tester', schema:'fake_schema_hash', data_version: 13},
         | {c:'row data',"truncate":true,"update":"replace","nonfatal_row_errors":["no_such_row_to_delete"]},
         | null,
         | {c:'row data',"truncate":false,"update":"merge","nonfatal_row_errors":[]},

--- a/soda-fountain-lib/src/test/scala/com/socrata/soda/server/highlevel/ColumnDAOSpec.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/soda/server/highlevel/ColumnDAOSpec.scala
@@ -27,7 +27,7 @@ class ColumnDAOSpec extends FunSuiteLike
 
     val dao: ColumnDAO = new ColumnDAOImpl(dc, fbm, ns, col)
 
-    val result = dao.deleteColumn("user", dataset.resourceName, toDelete, "1234")
+    val result = dao.deleteColumn("user", dataset.resourceName, None, toDelete, "1234")
 
     result should be(ColumnNotFound(toDelete))
   }
@@ -47,7 +47,7 @@ class ColumnDAOSpec extends FunSuiteLike
 
     val dao: ColumnDAO = new ColumnDAOImpl(dc, fbm, ns, col)
 
-    val result = dao.deleteColumn("user", dataset.resourceName, toDelete.fieldName, requestId)
+    val result = dao.deleteColumn("user", dataset.resourceName, None, toDelete.fieldName, requestId)
 
     result should be(ColumnHasDependencies(toDelete.fieldName, Seq(dependency.fieldName)))
   }
@@ -62,12 +62,12 @@ class ColumnDAOSpec extends FunSuiteLike
     val ns = mock[NameAndSchemaStore]
     ns.expects('lookupDataset)(dataset.resourceName, Some(Latest))
       .returning(Some(dataset)).anyNumberOfTimes()
-    dc.expects('update)(*, *, *, *, *, *)
+    dc.expects('update)(*, *, *, *, *, *, *)
     val col = new ColumnSpecUtils(Random)
 
     val dao: ColumnDAO = new ColumnDAOImpl(dc, fbm, ns, col)
 
-    dao.deleteColumn("user", dataset.resourceName, toDelete.fieldName, requestId)
+    dao.deleteColumn("user", dataset.resourceName, None, toDelete.fieldName, requestId)
 
     // TODO : How can we pass in/validate the handler function passed to dc.update?
   }

--- a/soda-fountain-lib/src/test/scala/com/socrata/soda/server/metrics/QueryMetricTest.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/soda/server/metrics/QueryMetricTest.scala
@@ -255,8 +255,8 @@ private class QueryOnlyRowDAO(testDatasets: Set[TestDataset]) extends RowDAO {
     query(dataset, precondition, ifModifiedSince, "give me one row!", None, None, secondaryInstance, noRollup, obfuscateId,
           reqId, fuseColumns, None, debug, rs)
   }
-  def upsert[T](user: String, datasetRecord: DatasetRecordLike, data: Iterator[RowUpdate], reqId: String)(f: UpsertResult => T): T = ???
-  def upsert[T](user: String, datasetRecord: DatasetRecordLike, data: Iterator[RowUpdate], reqId: String, rowUpdateOption: RowUpdateOption)(f: UpsertResult => T): T = ???
-  def replace[T](user: String, datasetRecord: DatasetRecordLike, data: Iterator[RowUpdate], reqId: String)(f: UpsertResult => T): T = ???
-  def deleteRow[T](user: String, dataset: ResourceName, rowId: RowSpecifier, reqId: String)(f: UpsertResult => T): T = ???
+  def upsert[T](user: String, datasetRecord: DatasetRecordLike, expectedDataVersion: Option[Long], data: Iterator[RowUpdate], reqId: String)(f: UpsertResult => T): T = ???
+  def upsert[T](user: String, datasetRecord: DatasetRecordLike, expectedDataVersion: Option[Long], data: Iterator[RowUpdate], reqId: String, rowUpdateOption: RowUpdateOption)(f: UpsertResult => T): T = ???
+  def replace[T](user: String, datasetRecord: DatasetRecordLike, expectedDataVersion: Option[Long], data: Iterator[RowUpdate], reqId: String)(f: UpsertResult => T): T = ???
+  def deleteRow[T](user: String, dataset: ResourceName, expectedDataVersion: Option[Long], rowId: RowSpecifier, reqId: String)(f: UpsertResult => T): T = ???
 }


### PR DESCRIPTION
Right now the source of this gate is a header on the request (just
like the output path, X-SODA2-Truth-Version) or, for upserts, a query
param expectedDataVersion because core uses soda-java as a
soda-fountain client when upserting and it's not obvious how to plumb
a header through soda-java without impacting the public API presented
there.