### PR TITLE
EN-32793: update soql-reference version to 2.11.13

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,7 +24,7 @@ object Dependencies {
     val scalaj            = "0.3.15"
     val socrataHttp       = "3.11.4"
     val soqlBrita         = "1.4.1"
-    val soqlReference     = "2.11.11"
+    val soqlReference     = "2.11.13"
     val thirdPartyUtils   = "4.0.16"
     val curatorUtils      = "1.1.2"
     val typesafeConfig    = "1.0.2"


### PR DESCRIPTION
this update teaches the soqlpack encoder how to handle SoQLUrl