### PR TITLE
Enable HTTP content compression on requests to qc / dc.

### DIFF
--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/SodaFountain.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/SodaFountain.scala
@@ -131,6 +131,7 @@ class SodaFountain(config: SodaFountainConfig) extends Closeable {
 
   val httpClient = i(new HttpClientHttpClient(executor,
     HttpClientHttpClient.defaultOptions.
+      withContentCompression(true).
       withLivenessChecker(livenessChecker).
       withUserAgent("soda fountain")))
 


### PR DESCRIPTION
The CPU overhead is fairly minimal and the network cost adds up quickly.