### PR TITLE
EN-37321 Support unobfuscated row id in write

### DIFF
--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/RowDataTranslator.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/RowDataTranslator.scala
@@ -21,7 +21,8 @@ import com.socrata.soql.types.{SoQLNull, SoQLType, SoQLValue}
  */
 class RowDataTranslator(requestId: RequestId,
                         dataset: DatasetRecordLike,
-                        ignoreUnknownColumns: Boolean) {
+                        ignoreUnknownColumns: Boolean,
+                        obfuscateId: Boolean) {
   import RowDataTranslator._
 
   private[this] sealed abstract class ColumnResult
@@ -41,7 +42,8 @@ class RowDataTranslator(requestId: RequestId,
         case Some(cr) =>
           if (cache.size > map.size * 10)
             cache.clear() // bad user, but I'd rather spend CPU than memory
-          ColumnInfo(cr, JsonColumnRep.forClientType(cr.typ), JsonColumnRep.forDataCoordinatorType(cr.typ))
+          val rowIdRep = if (obfuscateId) JsonColumnRep.forClientType(cr.typ) else JsonColumnRep.forClientTypeClearId(cr.typ)
+          ColumnInfo(cr, rowIdRep, JsonColumnRep.forDataCoordinatorType(cr.typ))
         case None     => NoColumn(ColumnName(rawKey))
       }
     }

--- a/soda-fountain-lib/src/test/scala/com/socrata/soda/server/highlevel/RowDataTranslatorTest.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/soda/server/highlevel/RowDataTranslatorTest.scala
@@ -11,7 +11,7 @@ import org.scalatest.{Matchers, FunSuite}
 class RowDataTranslatorTest extends FunSuite with Matchers with DatasetsForTesting {
   val ds = TestDatasetWithComputedColumn.dataset
   val dsInfo = TestDatasetWithComputedColumn
-  val translator = new RowDataTranslator("a-request-id", ds, false)
+  val translator = new RowDataTranslator("a-request-id", ds, false, true)
 
   test("getInfoForColumnList") {
     val info = translator.getInfoForColumnList(Seq(ds.colId("source"), ds.colId(":id")))


### PR DESCRIPTION
To use plain row id, update both truth and pg secondary for the dataset in metadb as follow:
  1. update dataset_map set obfuscation_key = E'\\000' where resource_name = '_four-by-four'
  2. pass in $$obfuscate_id=false in both read and write (upsert) in resource/_four-by-four?$$obfuscate_id=false