### PR TITLE
EN-38315: Don't try to snapshot deleted datasets.

### DIFF
--- a/soda-fountain-lib/src/main/resources/com/socrata/soda/server/persistence/pg/20140613-add-computation-strategies-table.xml
+++ b/soda-fountain-lib/src/main/resources/com/socrata/soda/server/persistence/pg/20140613-add-computation-strategies-table.xml
@@ -5,6 +5,8 @@
                    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
     <changeSet author="Urmila Nadkarni" id="20140613-add-computation-strategies-table">
+        <validCheckSum>3:c8d5855e554b8bfc553cf7ec838ef806</validCheckSum>
+        <validCheckSum>3:2ae46fb695f4af0306d106199522fa15</validCheckSum>
         <sqlFile path="com/socrata/soda/server/persistence/pg/sql/computation_strategies_create.sql" splitStatements="false"/>
         <rollback>
             <dropTable tableName="computation_strategies"/>

--- a/soda-fountain-lib/src/main/resources/com/socrata/soda/server/persistence/pg/sql/computation_strategies_create.sql
+++ b/soda-fountain-lib/src/main/resources/com/socrata/soda/server/persistence/pg/sql/computation_strategies_create.sql
@@ -5,6 +5,8 @@ CREATE TABLE IF NOT EXISTS computation_strategies (
   recompute                             BOOLEAN NOT NULL,
   source_columns                        TEXT[],
   parameters                            TEXT,
-  UNIQUE (dataset_system_id, column_id),
-  FOREIGN KEY (dataset_system_id, column_id) REFERENCES columns (dataset_system_id, column_id)
+  UNIQUE (dataset_system_id, column_id)
 );
+
+-- Explicitly name the foreign key for backwards compatibility as postgres 12.0 changed the default name for foreign keys to include all columns
+ALTER TABLE computation_strategies ADD CONSTRAINT computation_strategies_dataset_system_id_fkey FOREIGN KEY (dataset_system_id, column_id) REFERENCES columns(dataset_system_id, column_id);

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/persistence/NameAndSchemaStore.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/persistence/NameAndSchemaStore.scala
@@ -48,7 +48,7 @@ trait NameAndSchemaStore {
   def updateVersionInfo(datasetId: DatasetId, dataVersion: Long, lastModified: DateTime, stage: Option[Stage], copyNumber: Long, snapshotLimit: Option[Int]): Unit
   def makeCopy(datasetId: DatasetId, copyNumber: Long, dataVersion: Long): Unit
 
-  def bulkDatasetLookup(id: Set[DatasetId]): Set[ResourceName]
+  def bulkDatasetLookup(id: Set[DatasetId], includeDeleted: Boolean = false): Set[ResourceName]
 
   def withColumnUpdater[T](datasetId: DatasetId, copyNumber: Long, columnId: ColumnId)(f: NameAndSchemaStore.ColumnUpdater => T): T
 }


### PR DESCRIPTION
Currently snapshotter is looping constantly trying to snapshot datasets
that are deleted, and failing because they can't be accessed because they
are marked deleted.  To avoid this we filter out deleted datasets.

The only other uses of bulkDatasetLookup are in collation related code, and
they don't make sense for deleted datasets either and/or already won't work
if the dataset is deleted.  I'm adding it as a paramter instead of
hardcoding it to help any future users of the method think about if they
want to include deleted datasets or not.