### PR TITLE
If a deleted dataset isn't known to data-coordinator, drop it.

### DIFF
--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/DatasetDAOImpl.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/DatasetDAOImpl.scala
@@ -201,7 +201,10 @@ class DatasetDAOImpl(dc: DataCoordinatorClient,
               retry()
               // should only have two error case for this path.
             case DataCoordinatorClient.DatasetNotFoundResult(_) =>
-              DatasetNotFound(dataset)
+              // if it isn't known to dc, consider it gone
+              log.warn(s"Dataset $dataset / ${datasetRecord.systemId} not found in data-coordinator, removing from soda-fountain")
+              store.removeResource(dataset)
+              Deleted
             case DataCoordinatorClient.CannotAcquireDatasetWriteLockResult(_) =>
               CannotAcquireDatasetWriteLock(dataset)
             case DataCoordinatorClient.DatasetVersionMismatchResult(_, v) =>


### PR DESCRIPTION
We currently have various datasets that don't exist on truth any more but
are still in soda fountain and it is constantly looping through trying to
delete them.

The error handling and logging here could use a much bigger overhaul, but I'm
leaving that alone for now.