### PR TITLE
EN-54122: update jenkinsfile for releasing with no changes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,6 @@ pipeline {
   }
   parameters {
     booleanParam(name: 'RELEASE_CUT', defaultValue: false, description: 'Are we cutting a new release candidate?')
-    booleanParam(name: 'FORCE_BUILD', defaultValue: false, description: 'Force build from latest tag if sbt release needed to be run between cuts')
     string(name: 'AGENT', defaultValue: 'build-worker-pg13', description: 'Which build agent to use?')
     string(name: 'BRANCH_SPECIFIER', defaultValue: default_branch_specifier, description: 'Use this branch for building the artifact.')
   }
@@ -59,9 +58,8 @@ pipeline {
           service_sha = sh(returnStdout: true, script: "git rev-parse HEAD").trim()
 
           // determine what triggered the build and what stages need to be run
-          if (params.RELEASE_CUT == true) { // RELEASE_CUT parameter was set by a cut job
+          if (params.RELEASE_CUT) { // RELEASE_CUT parameter was set by a cut job
             stage_cut = true  // other stages will be turned on in the cut step as needed
-            stage_publish = true
             deploy_environment = "rc"
           }
           else if (env.CHANGE_ID != null) { // we're running a PR builder
@@ -85,21 +83,14 @@ pipeline {
       when { expression { stage_cut } }
       steps {
         script {
-          def cutNeeded = false
-
           // get a list of all files changes since the last tag
           files = sh(returnStdout: true, script: "git diff --name-only HEAD `git describe --match \"v*\" --abbrev=0`").trim()
           echo "Files changed:\n${files}"
 
           if (files == 'version.sbt') {
-            // Build anyway using latest tag - needed if sbt release had to be run between cuts
-            // This parameter will need to be set by the cut job in Jenkins
-            if(params.FORCE_BUILD) {
-              cutNeeded = true
-            }
-            else {
-              echo "No build needed, skipping subsequent steps"
-            }
+            echo 'No changes to the repo.  Rebuilding using the latest tag.'
+            // For release cuts, we want to rebuild and deploy even if there are no changes to the repo to pick up base layer changes for aqua compliance
+            stage_publish = false // artifactory does not let us publish without changes
           }
           else {
             echo 'Running sbt-release'
@@ -111,26 +102,24 @@ pipeline {
 
             echo sh(returnStdout: true, script: "echo y | sbt \"release with-defaults\"")
 
-            cutNeeded = true
+            stage_publish = true
           }
 
-          if(cutNeeded == true) {
-            echo 'Getting release tag'
-            release_tag = sh(returnStdout: true, script: "git describe --abbrev=0 --match \"v*\"").trim()
-            branchSpecifier = "refs/tags/${release_tag}"
-            echo branchSpecifier
+          echo 'Getting release tag'
+          release_tag = sh(returnStdout: true, script: "git describe --abbrev=0 --match \"v*\"").trim()
+          branchSpecifier = "refs/tags/${release_tag}"
+          echo branchSpecifier
 
-            // checkout the tag so we're performing subsequent actions on it
-            sh "git checkout ${branchSpecifier}"
+          // checkout the tag so we're performing subsequent actions on it
+          sh "git checkout ${branchSpecifier}"
 
-            // set the service_sha to the current tag because it might not be the same as env.GIT_COMMIT
-            service_sha = sh(returnStdout: true, script: "git rev-parse HEAD").trim()
+          // set the service_sha to the current tag because it might not be the same as env.GIT_COMMIT
+          service_sha = sh(returnStdout: true, script: "git rev-parse HEAD").trim()
 
-            // set later stages to run since we're cutting
-            stage_build = true
-            stage_dockerize = true
-            stage_deploy = true
-          }
+          // set later stages to run since we're cutting
+          stage_build = true
+          stage_dockerize = true
+          stage_deploy = true
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,7 +59,10 @@ pipeline {
 
           // determine what triggered the build and what stages need to be run
           if (params.RELEASE_CUT) { // RELEASE_CUT parameter was set by a cut job
-            stage_cut = true  // other stages will be turned on in the cut step as needed
+            stage_cut = true // stage_publish is turned on in the cut step as needed
+            stage_build = true
+            stage_dockerize = true
+            stage_deploy = true
             deploy_environment = "rc"
           }
           else if (env.CHANGE_ID != null) { // we're running a PR builder
@@ -115,11 +118,6 @@ pipeline {
 
           // set the service_sha to the current tag because it might not be the same as env.GIT_COMMIT
           service_sha = sh(returnStdout: true, script: "git rev-parse HEAD").trim()
-
-          // set later stages to run since we're cutting
-          stage_build = true
-          stage_dockerize = true
-          stage_deploy = true
         }
       }
     }


### PR DESCRIPTION
## Before

For release cuts, it would exit if there were no changes and the "FORCE_BUILD" option was false.
If the "FORCE_BUILD" option was true, then it would fail in the "Publish" stage because artifactory doesn't let us publish if there are no changes.
However, we now need to rebuild and deploy even if there are no changes to the repo to pick up base layer changes for aqua compliance.

## After
For release cuts, if there are no changes, it will rebuild from the current tag and skip the publish stage.
I removed the "FORCE_BUILD" logic since we want that to happen every time "RELEASE_CUT" is true.  I'll remove the "FORCE_BUILD" parameter from the cut job once this is merged.
