### PR TITLE
Expand error (type) handling when bad rollup is encountered

### DIFF
--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/DatasetDAOImpl.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/DatasetDAOImpl.scala
@@ -467,9 +467,12 @@ class DatasetDAOImpl(dc: DataCoordinatorClient,
                 log.debug(s"Mapped soql for rollup ${rollup} is: ${mappedQueries}")
                 RollupSpec(name = rollup.name, soql = mappedQueries.toString())
               } catch {
-                case _: BadParse =>
-                  log.info(s"invalid rollup SoQL ${rollup.name} ${rollup.soql}")
+                case ex: BadParse =>
+                  log.warn(s"invalid rollup SoQL ${rollup.name} ${rollup.soql} ${ex.getMessage}")
                   RollupSpec(name = rollup.name, soql = "__Invalid SoQL__")
+                case ex: Exception =>
+                  log.warn(s"invalid rollup SoQL ${rollup.name} ${rollup.soql} ${ex.getMessage}")
+                  RollupSpec(name = rollup.name, soql = "__Invalid Rollup__")
               }
             }
 


### PR DESCRIPTION
Previously we only catch parse error.  But there is more work after parsing that has potential to err.