### PR TITLE
EN-54831 - pass lens id through to query coordinator

### DIFF
--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/querycoordinator/HttpQueryCoordinatorClient.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/querycoordinator/HttpQueryCoordinatorClient.scala
@@ -61,17 +61,17 @@ trait HttpQueryCoordinatorClient extends QueryCoordinatorClient {
     copy: Option[Stage], secondaryInstance:Option[String], noRollup: Boolean,
     obfuscateId: Boolean,
     extraHeaders: Map[String, String], queryTimeoutSeconds: Option[String],
-    rs: ResourceScope, lensUid: String)(f: Result => T): T = {
+    rs: ResourceScope, lensUid: Option[String])(f: Result => T): T = {
 
     val params = List(
       qpDataset -> dataset.datasetId.underlying,
       qpQuery -> query,
-      qpLensUid -> lensUid,
       qpContext -> JsonUtil.renderJson(context, pretty=false)) ++
       // when $$query_timeout_seconds is not given, always limit it to the default value - typically 10 minutes
       queryTimeoutSeconds.orElse(Some(defaultReceiveTimeout.toSeconds.toString)).map(qpQueryTimeoutSeconds -> _) ++
       copy.map(c => List(qpCopy -> c.name.toLowerCase)).getOrElse(Nil) ++ // Query coordinate needs publication stage in lower case.
       rowCount.map(rc => List(qpRowCount -> rc)).getOrElse(Nil) ++
+      lensUid.map(uid => List(qpLensUid -> uid)).getOrElse(Nil) ++
       (if (noRollup) List(qpNoRollup -> "y") else Nil) ++
       (if (!obfuscateId) List(qpObfuscateId -> "false") else Nil) ++
       secondaryInstance.map(so => List(secondaryStoreOverride -> so)).getOrElse(Nil)

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/querycoordinator/HttpQueryCoordinatorClient.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/querycoordinator/HttpQueryCoordinatorClient.scala
@@ -38,6 +38,7 @@ trait HttpQueryCoordinatorClient extends QueryCoordinatorClient {
   private val qpNoRollup = "no_rollup"
   private val qpObfuscateId = "obfuscateId"
   private val qpQueryTimeoutSeconds = "queryTimeoutSeconds"
+  private val qpLensUid = "lensUid"
 
   private def retrying[T](limit: Int)(f: => T): T = {
     def doRetry(count: Int, e: Exception): T = {
@@ -60,11 +61,12 @@ trait HttpQueryCoordinatorClient extends QueryCoordinatorClient {
     copy: Option[Stage], secondaryInstance:Option[String], noRollup: Boolean,
     obfuscateId: Boolean,
     extraHeaders: Map[String, String], queryTimeoutSeconds: Option[String],
-    rs: ResourceScope)(f: Result => T): T = {
+    rs: ResourceScope, lensUid: String)(f: Result => T): T = {
 
     val params = List(
       qpDataset -> dataset.datasetId.underlying,
       qpQuery -> query,
+      qpLensUid -> lensUid,
       qpContext -> JsonUtil.renderJson(context, pretty=false)) ++
       // when $$query_timeout_seconds is not given, always limit it to the default value - typically 10 minutes
       queryTimeoutSeconds.orElse(Some(defaultReceiveTimeout.toSeconds.toString)).map(qpQueryTimeoutSeconds -> _) ++

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/querycoordinator/QueryCoordinatorClient.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/querycoordinator/QueryCoordinatorClient.scala
@@ -85,6 +85,7 @@ trait QueryCoordinatorClient {
                obfuscateId: Boolean,
                extraHeaders: Map[String, String],
                queryTimeoutSeconds: Option[String],
-               rs: ResourceScope)(f: Result => T): T
+               rs: ResourceScope,
+               lensUid: String)(f: Result => T): T
 
 }

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/querycoordinator/QueryCoordinatorClient.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/querycoordinator/QueryCoordinatorClient.scala
@@ -86,6 +86,6 @@ trait QueryCoordinatorClient {
                extraHeaders: Map[String, String],
                queryTimeoutSeconds: Option[String],
                rs: ResourceScope,
-               lensUid: String)(f: Result => T): T
+               lensUid: Option[String])(f: Result => T): T
 
 }

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/RowDAO.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/RowDAO.scala
@@ -34,7 +34,7 @@ trait RowDAO {
             queryTimeoutSeconds: Option[String],
             debugInfo: DebugInfo,
             resourceScope: ResourceScope,
-            lensUid: String): Result
+            lensUid: Option[String]): Result
 
   def getRow(dataset: ResourceName,
              precondition: Precondition,
@@ -48,7 +48,7 @@ trait RowDAO {
              queryTimeoutSeconds: Option[String],
              debugInfo: DebugInfo,
              resourceScope: ResourceScope,
-             lensUid: String): Result
+             lensUid: Option[String]): Result
 
   def upsert[T](user: String,
                 datasetRecord: DatasetRecordLike,

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/RowDAO.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/RowDAO.scala
@@ -33,7 +33,8 @@ trait RowDAO {
             fuseColumns: Option[String],
             queryTimeoutSeconds: Option[String],
             debugInfo: DebugInfo,
-            resourceScope: ResourceScope): Result
+            resourceScope: ResourceScope,
+            lensUid: String): Result
 
   def getRow(dataset: ResourceName,
              precondition: Precondition,
@@ -46,7 +47,8 @@ trait RowDAO {
              fuseColumns: Option[String],
              queryTimeoutSeconds: Option[String],
              debugInfo: DebugInfo,
-             resourceScope: ResourceScope): Result
+             resourceScope: ResourceScope,
+             lensUid: String): Result
 
   def upsert[T](user: String,
                 datasetRecord: DatasetRecordLike,

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/RowDAOImpl.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/RowDAOImpl.scala
@@ -41,11 +41,12 @@ class RowDAOImpl(store: NameAndSchemaStore, dc: DataCoordinatorClient, qc: Query
             fuseColumns: Option[String],
             queryTimeoutSeconds: Option[String],
             debugInfo: DebugInfo,
-            resourceScope: ResourceScope): Result = {
+            resourceScope: ResourceScope,
+            lensUid: String): Result = {
     store.lookupDataset(resourceName, copy) match {
       case Some(ds) =>
         getRows(ds, precondition, ifModifiedSince, query, context, rowCount, copy, secondaryInstance, noRollup, obfuscateId,
-          fuseColumns, queryTimeoutSeconds, debugInfo, resourceScope)
+          fuseColumns, queryTimeoutSeconds, debugInfo, resourceScope, lensUid)
       case None =>
         log.info("dataset not found {}", resourceName.name)
         DatasetNotFound(resourceName)
@@ -63,7 +64,8 @@ class RowDAOImpl(store: NameAndSchemaStore, dc: DataCoordinatorClient, qc: Query
              fuseColumns: Option[String],
              queryTimeoutSeconds: Option[String],
              debugInfo: DebugInfo,
-             resourceScope: ResourceScope): Result = {
+             resourceScope: ResourceScope,
+             lensUid: String): Result = {
     store.lookupDataset(resourceName, copy) match {
       case Some(datasetRecord) =>
         val pkCol = datasetRecord.columnsById(datasetRecord.primaryKey)
@@ -76,7 +78,7 @@ class RowDAOImpl(store: NameAndSchemaStore, dc: DataCoordinatorClient, qc: Query
             getRows(datasetRecord, NoPrecondition, ifModifiedSince, query,
                     Context.empty, // no context needed
                     None, copy, secondaryInstance,
-                    noRollup, obfuscateId, fuseColumns, queryTimeoutSeconds, debugInfo, resourceScope) match {
+                    noRollup, obfuscateId, fuseColumns, queryTimeoutSeconds, debugInfo, resourceScope, lensUid) match {
               case QuerySuccess(_, truthVersion, truthLastModified, rollup, simpleSchema, rows) =>
                 val version = ColumnName(":version")
                 val versionPos = simpleSchema.schema.indexWhere(_.fieldName == version)
@@ -125,7 +127,8 @@ class RowDAOImpl(store: NameAndSchemaStore, dc: DataCoordinatorClient, qc: Query
                       fuseColumns: Option[String],
                       queryTimeoutSeconds: Option[String],
                       debugInfo: DebugInfo,
-                      resourceScope: ResourceScope): Result = {
+                      resourceScope: ResourceScope,
+                      lensUid: String): Result = {
     val extraHeaders = Map(
                            "X-SODA2-DataVersion"    -> ds.truthVersion.toString,
                            "X-SODA2-LastModified"   -> ds.lastModified.toHttpDate) ++
@@ -134,7 +137,7 @@ class RowDAOImpl(store: NameAndSchemaStore, dc: DataCoordinatorClient, qc: Query
       (if (debugInfo.explain) Map("X-Socrata-Explain" -> "true") else Map.empty) ++
       (if (debugInfo.analyze) Map("X-Socrata-Analyze" -> "true") else Map.empty)
     qc.query(ds.handle, precondition, ifModifiedSince, query, context, rowCount,
-             copy, secondaryInstance, noRollup, obfuscateId, extraHeaders, queryTimeoutSeconds, resourceScope) {
+             copy, secondaryInstance, noRollup, obfuscateId, extraHeaders, queryTimeoutSeconds, resourceScope, lensUid) {
       case QueryCoordinatorClient.Success(etags, rollup, lastModifiedStr, response) if !debugInfo.explain =>
         val jsonColumnReps = if (obfuscateId) JsonColumnRep.forDataCoordinatorType
                              else JsonColumnRep.forDataCoordinatorTypeClearId

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/RowDAOImpl.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/highlevel/RowDAOImpl.scala
@@ -42,7 +42,7 @@ class RowDAOImpl(store: NameAndSchemaStore, dc: DataCoordinatorClient, qc: Query
             queryTimeoutSeconds: Option[String],
             debugInfo: DebugInfo,
             resourceScope: ResourceScope,
-            lensUid: String): Result = {
+            lensUid: Option[String]): Result = {
     store.lookupDataset(resourceName, copy) match {
       case Some(ds) =>
         getRows(ds, precondition, ifModifiedSince, query, context, rowCount, copy, secondaryInstance, noRollup, obfuscateId,
@@ -65,7 +65,7 @@ class RowDAOImpl(store: NameAndSchemaStore, dc: DataCoordinatorClient, qc: Query
              queryTimeoutSeconds: Option[String],
              debugInfo: DebugInfo,
              resourceScope: ResourceScope,
-             lensUid: String): Result = {
+             lensUid: Option[String]): Result = {
     store.lookupDataset(resourceName, copy) match {
       case Some(datasetRecord) =>
         val pkCol = datasetRecord.columnsById(datasetRecord.primaryKey)
@@ -128,7 +128,7 @@ class RowDAOImpl(store: NameAndSchemaStore, dc: DataCoordinatorClient, qc: Query
                       queryTimeoutSeconds: Option[String],
                       debugInfo: DebugInfo,
                       resourceScope: ResourceScope,
-                      lensUid: String): Result = {
+                      lensUid: Option[String]): Result = {
     val extraHeaders = Map(
                            "X-SODA2-DataVersion"    -> ds.truthVersion.toString,
                            "X-SODA2-LastModified"   -> ds.lastModified.toHttpDate) ++

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/Resource.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/Resource.scala
@@ -207,7 +207,8 @@ case class Resource(etagObfuscator: ETagObfuscator, maxRowSize: Long, metricProv
                     req.header("X-Socrata-Explain").isDefined,
                     req.header("X-Socrata-Analyze").isDefined
                   ),
-                  req.resourceScope) match {
+                  req.resourceScope,
+                  req.header("X-Socrata-Lens-Uid").get) match {
                   case RowDAO.QuerySuccess(etags, truthVersion, truthLastModified, rollup, schema, rows) =>
                     metric(QuerySuccessMetric)
                     if (isConditionalGet(req)) {
@@ -385,7 +386,8 @@ case class Resource(etagObfuscator: ETagObfuscator, maxRowSize: Long, metricProv
                       req.header("X-Socrata-Explain").isDefined,
                       req.header("X-Socrata-Analyze").isDefined
                     ),
-                    resourceScope) match {
+                    resourceScope,
+                    req.header("X-Socrata-Lens-Uid").get) match {
                     case RowDAO.SingleRowQuerySuccess(etags, truthVersion, truthLastModified, schema, row) =>
                       metric(QuerySuccessMetric)
                       if (isConditionalGet(req)) {

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/Resource.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/Resource.scala
@@ -208,7 +208,7 @@ case class Resource(etagObfuscator: ETagObfuscator, maxRowSize: Long, metricProv
                     req.header("X-Socrata-Analyze").isDefined
                   ),
                   req.resourceScope,
-                  req.header("X-Socrata-Lens-Uid").get) match {
+                  lensUid) match {
                   case RowDAO.QuerySuccess(etags, truthVersion, truthLastModified, rollup, schema, rows) =>
                     metric(QuerySuccessMetric)
                     if (isConditionalGet(req)) {
@@ -387,7 +387,7 @@ case class Resource(etagObfuscator: ETagObfuscator, maxRowSize: Long, metricProv
                       req.header("X-Socrata-Analyze").isDefined
                     ),
                     resourceScope,
-                    req.header("X-Socrata-Lens-Uid").get) match {
+                    lensUid) match {
                     case RowDAO.SingleRowQuerySuccess(etags, truthVersion, truthLastModified, schema, row) =>
                       metric(QuerySuccessMetric)
                       if (isConditionalGet(req)) {

--- a/soda-fountain-lib/src/test/scala/com/socrata/soda/server/metrics/QueryMetricTest.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/soda/server/metrics/QueryMetricTest.scala
@@ -269,12 +269,12 @@ private object TestDatasets {
 private class QueryOnlyRowDAO(testDatasets: Set[TestDataset]) extends RowDAO {
   def query(dataset: ResourceName, precondition: Precondition, ifModifiedSince: Option[DateTime], query: String, context: Context, rowCount: Option[String],
             stage: Option[Stage], secondaryInstance: Option[String], noRollup: Boolean, obfuscateId: Boolean,
-            fuseColumns: Option[String], queryTimeoutSeconds: Option[String], debugInfo: DebugInfo, rs: ResourceScope, lensUid: String): Result = {
+            fuseColumns: Option[String], queryTimeoutSeconds: Option[String], debugInfo: DebugInfo, rs: ResourceScope, lensUid: Option[String]): Result = {
     testDatasets.find(_.resource == dataset).map(_.getResult).getOrElse(throw new Exception("TestDataset not defined"))
   }
   def getRow(dataset: ResourceName, precondition: Precondition, ifModifiedSince: Option[DateTime], rowId: RowSpecifier,
              stage: Option[Stage], secondaryInstance: Option[String], noRollup: Boolean, obfuscateId: Boolean,
-             fuseColumns: Option[String], queryTimeoutSeconds: Option[String], debugInfo: DebugInfo, rs: ResourceScope, lensUid: String): Result = {
+             fuseColumns: Option[String], queryTimeoutSeconds: Option[String], debugInfo: DebugInfo, rs: ResourceScope, lensUid: Option[String]): Result = {
     query(dataset, precondition, ifModifiedSince, "give me one row!", Context.empty, None, None, secondaryInstance, noRollup, obfuscateId,
           fuseColumns, None, debugInfo, rs, lensUid)
   }


### PR DESCRIPTION
Query coordinator needs the lens id for soql analysis. Core sends it but soda fountain was swallowing it.