### PR TITLE
EN-55220: soql-reference version bump, for column name mapping fix

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
     val slf4j             = "1.7.33"
     val socrataHttp       = "3.16.0"
     val soqlBrita         = "1.4.1"
-    val soqlReference     = "4.11.4"
+    val soqlReference     = "4.12.1"
     val thirdPartyUtils   = "5.0.0"
     val curatorUtils      = "1.2.0"
     val typesafeConfig    = "1.0.2"


### PR DESCRIPTION
Need to propagate a fix in soql-reference