### PR TITLE
EN-60548: Fake-locations on the new query path

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
     val slf4j             = "1.7.33"
     val socrataHttp       = "3.16.0"
     val soqlBrita         = "1.4.1"
-    val soqlReference     = "4.12.12"
+    val soqlReference     = "4.12.13"
     val thirdPartyUtils   = "5.0.0"
     val curatorUtils      = "1.2.0"
     val typesafeConfig    = "1.0.2"

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/querycoordinator/QueryCoordinatorClient.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/querycoordinator/QueryCoordinatorClient.scala
@@ -89,7 +89,7 @@ object QueryCoordinatorClient {
   }
 }
 
-trait QueryCoordinatorClient {
+trait QueryCoordinatorClient extends analyzer2.LabelUniverse[QueryCoordinatorClient.MetaTypes] {
   import QueryCoordinatorClient._
   def query[T](dataset: DatasetHandle,
                precondition: Precondition,
@@ -108,6 +108,7 @@ trait QueryCoordinatorClient {
 
   def newQuery(
     tables: analyzer2.UnparsedFoundTables[MetaTypes],
+    locationSubcolumns: Map[DatabaseTableName, Map[DatabaseColumnName, Seq[Option[DatabaseColumnName]]]],
     context: NewContext,
     rewritePasses: Seq[Seq[Pass]],
     preserveSystemColumns: Boolean,


### PR DESCRIPTION
When told we're looking at a location column, find its subcolumns and pass this information down to query-coordinator