### PR TITLE
Simplify assembly filename

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,6 +75,7 @@ pipeline {
           sbtbuild.setNoSubproject(true)
           sbtbuild.setScalaVersion("2.12")
           sbtbuild.setSubprojectName("sodaFountainJetty")
+          sbtbuild.setSrcJar("soda-fountain-jetty/target/soda-fountain-jetty-assembly.jar")
 
           // build
           echo "Building sbt project..."

--- a/soda-fountain-jetty/build.sbt
+++ b/soda-fountain-jetty/build.sbt
@@ -11,3 +11,7 @@ libraryDependencies ++= Seq(
 )
 
 mainClass := Some("com.socrata.soda.server.SodaFountainJetty")
+
+assembly/assemblyJarName := s"${name.value}-assembly.jar"
+
+assembly/assemblyOutputPath := target.value / (assembly/assemblyJarName).value


### PR DESCRIPTION
* The filename no longer contains the version number
* The file is stored in target instead of target/scala-$version