### PR TITLE
EN-65713: move release tagging

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -156,7 +156,7 @@ pipeline {
               ]
               createBuild(
                 buildInfo,
-                rmsSupportedEnvironment.staging //production
+                rmsSupportedEnvironment.production
               )
             }
           }


### PR DESCRIPTION
This commit moves the release tagging after a successful docker build. In order to do this, it separates the docker build from the publishing of the images into separate Jenkinsfile steps.