### PR TITLE
Make listing rollups work with "legacy" new-analyzer rollups

### DIFF
--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/id/AbstractId.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/id/AbstractId.scala
@@ -12,7 +12,18 @@ trait AbstractId {
 }
 
 case class DatasetInternalName(underlying: String) extends AbstractId {
-  def nativeDataCoordinator = underlying.substring(0, underlying.lastIndexOf('.'))
+  private val dotIndex = underlying.lastIndexOf('.')
+  if(dotIndex == -1) {
+    throw new IllegalArgumentException("Malformed internal name")
+  }
+  val datasetId = try {
+    java.lang.Long.parseLong(underlying.substring(dotIndex + 1))
+  } catch {
+    case _ : NumberFormatException =>
+      throw new IllegalArgumentException("Malformed internal name")
+  }
+
+  def nativeDataCoordinator = underlying.substring(0, dotIndex)
 }
 
 object DatasetInternalName {

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/NewRollup.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/resources/NewRollup.scala
@@ -94,7 +94,9 @@ case object NewRollup {
                     // TODO better error
                     return BadRequest
                   }
-                  DatabaseTableName(resourceName) -> value.locationSubcolumns
+                  val tableName: DataCoordinatorClient.RollupMetaTypes.TableName =
+                    DataCoordinatorClient.RollupMetaTypes.TableName.ResourceName(resourceName)
+                  DatabaseTableName(tableName) -> value.locationSubcolumns
                 }.toMap
 
               val dcFoundTables = staged.rewriteDatabaseNames[DataCoordinatorClient.RollupMetaTypes](
@@ -103,7 +105,9 @@ case object NewRollup {
                     // TODO better error
                     return BadRequest
                   }
-                  DatabaseTableName(resourceName)
+                  val tableName: DataCoordinatorClient.RollupMetaTypes.TableName =
+                    DataCoordinatorClient.RollupMetaTypes.TableName.ResourceName(resourceName)
+                  DatabaseTableName(tableName)
                 },
                 cache.lookupColumnName(_, _).getOrElse {
                   // TODO better error

--- a/soda-fountain-lib/src/test/scala/com/socrata/datacoordinator/client/HttpDatatCoordinatorClientTest.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/datacoordinator/client/HttpDatatCoordinatorClientTest.scala
@@ -52,7 +52,7 @@ class HttpDatatCoordinatorClientTest extends AnyFunSuite with Matchers {
 
   test("A recognized Error from Data-Coordinator", tag) {
       val status = 404 // could be any 400 or 500 code except
-      val someDataset = "someDataset"
+      val someDataset = "someDataset.1234"
       val someColumn = "someColumn"
       val someCommandIndex = 40L
       val data = Map("dataset" -> JString(someDataset), "column" -> JString(someColumn), "commandIndex" -> JNumber(someCommandIndex))

--- a/soda-fountain-lib/src/test/scala/com/socrata/soda/server/DatasetsForTesting.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/soda/server/DatasetsForTesting.scala
@@ -20,7 +20,7 @@ trait DatasetsForTesting {
   def generateDataset(humanReadableTestIdentifier: String, columns: Seq[ColumnRecord]): DatasetRecord = {
     val time = System.currentTimeMillis().toString
     val resourceName = new ResourceName(s"$humanReadableTestIdentifier @$time")
-    val datasetId = new DatasetInternalName(s"id @$time")
+    val datasetId = new DatasetInternalName(s"id.$time")
 
     new DatasetRecord(
       resourceName,
@@ -69,7 +69,7 @@ trait DatasetsForTesting {
 
     val dataset = DatasetRecord(
       new ResourceName("test_resource"),
-      new DatasetInternalName("abcd-1234"),
+      new DatasetInternalName("abcd.1234"),
       "Test resource",
       "Description",
       "en_US",

--- a/soda-fountain-lib/src/test/scala/com/socrata/soda/server/persistence/SodaPostgresContainerTest.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/soda/server/persistence/SodaPostgresContainerTest.scala
@@ -15,7 +15,7 @@ trait SodaPostgresContainerTest extends PostgresContainerTest with MockFactory {
   def generateDataset(humanReadableTestIdentifier: String, columns: Seq[ColumnRecord]): DatasetRecord = {
     val time = System.currentTimeMillis().toString
     val resourceName = new ResourceName(s"${humanReadableTestIdentifier}_$time")
-    val datasetId = new DatasetInternalName(s"id_$time")
+    val datasetId = new DatasetInternalName(s"id.$time")
 
     new DatasetRecord(
       resourceName,


### PR DESCRIPTION
Before these would display as "invalid soql" because SF wouldn't know what to do with internal names it gets back from DC; now they display properly.