### PR TITLE
EN-68825: Make j2 template safer for resource groups RESOURCE_GROUPS_API_HOST

### DIFF
--- a/docker/soda-fountain.conf.j2
+++ b/docker/soda-fountain.conf.j2
@@ -20,8 +20,10 @@ com.socrata.soda-fountain  {
   }
 
   resource-groups-client {
-    apiHost = {{ RESOURCE_GROUPS_API_HOST }}
-  }
+      {% if RESOURCE_GROUPS_API_HOST is defined %}
+      apiHost = {{ RESOURCE_GROUPS_API_HOST }}
+      {% endif %}
+    }
 
   metrics {
     enable-graphite = {{ ENABLE_GRAPHITE }}

--- a/docker/soda-fountain.conf.j2
+++ b/docker/soda-fountain.conf.j2
@@ -20,10 +20,10 @@ com.socrata.soda-fountain  {
   }
 
   resource-groups-client {
-      {% if RESOURCE_GROUPS_API_HOST is defined %}
-      apiHost = {{ RESOURCE_GROUPS_API_HOST }}
-      {% endif %}
-    }
+    {% if RESOURCE_GROUPS_API_HOST is defined %}
+    apiHost = {{ RESOURCE_GROUPS_API_HOST }}
+    {% endif %}
+  }
 
   metrics {
     enable-graphite = {{ ENABLE_GRAPHITE }}


### PR DESCRIPTION
This avoids the issue of not having a RESOURCE_GROUPS_API_HOST present.