### PR TITLE
EN-68827: fix hotfix build error

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -111,8 +111,8 @@ pipeline {
           lastStage = env.STAGE_NAME
           if (params.RELEASE_BUILD || isHotfix) {
             env.VERSION = (isHotfix) ? env.HOTFIX_NAME : params.RELEASE_NAME
-              env.DOCKER_TAG = dockerize.dockerBuildWithSpecificTag(
-              tag: params.RELEASE_NAME,
+            env.DOCKER_TAG = dockerize.dockerBuildWithSpecificTag(
+              tag: env.VERSION,
               path: env.DOCKER_PATH,
               artifacts: [sbtbuild.getDockerArtifact()]
             )


### PR DESCRIPTION
This commit fixes a build error that happened on a hotfix -- the build tag was absent from the docker build command.